### PR TITLE
fix(ios): resolve fontFamily through the family's font names

### DIFF
--- a/android/src/main/jni/react/renderer/components/RNPlainTextSpec/PlainTextMeasurementsManager.cpp
+++ b/android/src/main/jni/react/renderer/components/RNPlainTextSpec/PlainTextMeasurementsManager.cpp
@@ -58,8 +58,8 @@ Size PlainTextMeasurementsManager::measure(
   if (!props.fontWeight.empty()) {
     serializedProps["fontWeight"] = props.fontWeight;
   }
-  if (props.fontStyle != RNPlainTextFontStyle::Normal) {
-    serializedProps["fontStyle"] = toString(props.fontStyle);
+  if (!props.fontStyle.empty()) {
+    serializedProps["fontStyle"] = props.fontStyle;
   }
   if (!props.fontVariant.empty()) {
     // A dynamic array, so it arrives as a ReadableArray — what RN's own

--- a/docs/agent/native-gotchas.md
+++ b/docs/agent/native-gotchas.md
@@ -301,3 +301,16 @@ Learned the hard way. Most of these cost an afternoon the first time.
   so `"text-size"` can split as `"text-"` / `"size"` on iOS. Use a non-breaking
   hyphen (U+2011, `‑`) where that split is unwanted — see the "Non-breaking
   hyphen" row in the Features screen's Font Scaling section.
+- **Accepted: under Dynamic Type, `fontSize` is rounded to whole points but
+  `lineHeight` is not, so the font/lineHeight ratio drifts slightly at some
+  multipliers.** `scaledFontSize` (`PlainTextFont.mm:444-450`) rounds when a
+  multiplier applies; `lineHeight = props.lineHeight * fontSizeMultiplier` in
+  both `PlainTextShadowNode.mm` and `RNPlainText.mm` never does. This exactly
+  matches RN `<Text>`: `RCTFont.mm:421-422` rounds font size the same way, and
+  `RCTAttributedTextUtils.mm:241-244` computes `lineHeight * multiplier` with no
+  rounding. Flagged in code review as a possible follow-up; deliberately not
+  "fixed" by rounding `lineHeight` too — that would trade a real (if small)
+  parity gap with RN `<Text>` for a cosmetic ratio fix nobody has reported
+  seeing, and this library's whole reason to exist is matching `<Text>`
+  pixel-for-pixel. Revisit only given a concrete visual complaint that traces
+  back to this, not preemptively.

--- a/docs/agent/performance.md
+++ b/docs/agent/performance.md
@@ -358,14 +358,32 @@ at all.
 `PlainTextShadowNode::measureContent` resolved the same `UIFont` from the same
 props — so mounting 1000 items ran 2000 uncached resolutions for what is usually
 a single distinct font. Both now call `plainTextFont`, backed by an `NSCache`
-keyed on the only four inputs that reach `UIFont`: family, size, weight, italic.
+keyed on the only six inputs that reach `UIFont`: family, size, weight, italic,
+variants and variation settings.
 
 Resolution is not free, which is why RN caches its own system fonts the same way
-(`RCTFont.mm`, `cachedSystemFont`). The custom-family path is the expensive one:
-`fontDescriptorWithFontAttributes:` + `fontWithDescriptor:` matches against the
-font database, and italic adds a second descriptor round-trip. `UIFont` and
-`NSCache` are both thread-safe, so the shadow thread and the main thread share
-one cache.
+(`RCTFont.mm`, `cachedSystemFont`). `UIFont` and `NSCache` are both thread-safe,
+so the shadow thread and the main thread share one cache.
+
+The custom-family path is the expensive one, and got more so when face selection
+started mirroring `RCTFont.mm` face by face (for the parity reasons in that file's
+comments) instead of matching one font descriptor: a miss over N faces
+instantiates N fonts, queries 2N symbolic traits and runs N `RCTGetFontWeight`
+calls. Two more caches and a short-circuit keep that off the hot path:
+
+- **The family's face names, per family.** `+[UIFont fontNamesForFamilyName:]`
+  enumerates the font database — RN calls it expensive and wraps it identically.
+- **The winning face, per family/weight/style rather than per size.** Every input
+  the comparison reads belongs to the face, so the scan runs at a fixed probe size
+  and only the instantiation uses the real one. Without this, each new size re-ran
+  the scan to reach a name it already knew, and a type scale or a Dynamic Type
+  step is several new sizes.
+- **A single-face family skips the scan**, since the loop's result is provably
+  that one name. That is the shape of most custom and expo-registered fonts.
+
+The font cache has a `countLimit` because its key includes two continuous inputs,
+`fontSize` and the axis values in `fontVariationSettings`, which an app animating
+either would otherwise walk through without bound.
 
 This is the iOS counterpart to Android's batched typeface resolution, and unlike
 the changes above it _removes_ a sync point rather than adding one — the two

--- a/docs/agent/sync-points.md
+++ b/docs/agent/sync-points.md
@@ -44,8 +44,11 @@ the callers (RN doesn't round it), so it stays a sync point between them.
 
 `ios/PlainTextFontCacheKey.cpp` builds the keys behind `resolvedFaceName`'s and
 `plainTextFont`'s caches (`ios/PlainTextFont.mm`) from a fixed list of inputs:
-`faceCacheKey` takes `fontFamily`, `fontWeight` and italic; `fontCacheKey` adds
-`fontSize`, `fontVariant` and `fontVariationSettings` on top. That list has to
+`faceCacheKey` takes `fontFamily`, `fontWeight` and the raw `fontStyle` string
+(not a converted bool — an empty string and `"normal"` both mean "not italic"
+but must key separately, since `computeFaceName`'s face-name fallback tells
+them apart); `fontCacheKey` adds `fontSize`, `fontVariant` and
+`fontVariationSettings` on top. That list has to
 name every input `computeFaceName`/`resolvedFont` read to pick a face or build
 the `UIFont` — a new one read there and left out of the key doesn't fail to
 apply, it applies once and then serves that first value back for every other

--- a/docs/agent/sync-points.md
+++ b/docs/agent/sync-points.md
@@ -40,6 +40,20 @@ why it takes the multiplier rather than an already-scaled size: the rounding
 `RCTFont.mm` applies is then in one place instead of two. `lineHeight` scales in
 the callers (RN doesn't round it), so it stays a sync point between them.
 
+## The iOS font cache key
+
+`ios/PlainTextFontCacheKey.cpp` builds the keys behind `resolvedFaceName`'s and
+`plainTextFont`'s caches (`ios/PlainTextFont.mm`) from a fixed list of inputs:
+`faceCacheKey` takes `fontFamily`, `fontWeight` and italic; `fontCacheKey` adds
+`fontSize`, `fontVariant` and `fontVariationSettings` on top. That list has to
+name every input `computeFaceName`/`resolvedFont` read to pick a face or build
+the `UIFont` — a new one read there and left out of the key doesn't fail to
+apply, it applies once and then serves that first value back for every other
+one, keyed as if nothing had changed. Both caches are unbounded
+(`familyNamesCache`, `faceNamesCache`) or bounded only by count
+(`resolvedFontsCache`, `kFontCacheCountLimit`), so nothing evicts the stale
+entry on its own.
+
 ## The three-way default contract
 
 These must all agree, per prop:

--- a/docs/agent/sync-points.md
+++ b/docs/agent/sync-points.md
@@ -35,6 +35,11 @@ one exception: the `UIFont` itself is not mirrored. `fontFamily`, `fontSize`,
 (`ios/PlainTextFont.h`), so a change to font resolution lands on both sides at
 once. A new prop that feeds the font belongs in there, not in either caller.
 
+Accessibility scaling of the font size is inside it for the same reason, which is
+why it takes the multiplier rather than an already-scaled size: the rounding
+`RCTFont.mm` applies is then in one place instead of two. `lineHeight` scales in
+the callers (RN doesn't round it), so it stays a sync point between them.
+
 ## The three-way default contract
 
 These must all agree, per prop:

--- a/example/package.json
+++ b/example/package.json
@@ -14,6 +14,7 @@
     "build:web": "expo export --platform web"
   },
   "dependencies": {
+    "@expo-google-fonts/inter": "^0.4.2",
     "@expo/metro-runtime": "~57.0.8",
     "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.18.13",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,11 @@
 import { useCallback } from 'react';
 import { Platform, StyleSheet } from 'react-native';
+import {
+  useFonts,
+  Inter_300Light_Italic,
+  Inter_400Regular,
+  Inter_600SemiBold,
+} from '@expo-google-fonts/inter';
 import { Ionicons } from '@expo/vector-icons';
 import { NavigationContainer, type NavigationState } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
@@ -107,7 +113,22 @@ const TAB_SCREENS = TABS.map(({ title, route, icon, screen }) => ({
   ),
 }));
 
+// The keys are the names FeaturesScreen passes as fontFamily, and expo-font
+// registers each one as an alias for the face's real PostScript name
+// ("Inter_400Regular" ▸ "Inter-Regular"). One family, same names on both
+// platforms, which is what makes those rows comparable at all — every other font
+// in that section is a platform built-in.
+//
+// Gated rather than rendered through: an alias that hasn't been registered yet
+// resolves to the system font, which is precisely the failure the section exists
+// to show, so those rows would lie for as long as the load took.
 export default function App() {
+  const [fontsLoaded] = useFonts({
+    Inter_300Light_Italic,
+    Inter_400Regular,
+    Inter_600SemiBold,
+  });
+
   // Which tab was selected, kept across app kills for the rest of the session.
   const [initialTabName, setSelectedTab] = useSessionState<string | undefined>(
     'selected-tab',
@@ -122,6 +143,10 @@ export default function App() {
     },
     [setSelectedTab]
   );
+
+  if (!fontsLoaded) {
+    return null;
+  }
 
   return (
     <SafeAreaProvider>

--- a/example/src/screens/FeaturesScreen.tsx
+++ b/example/src/screens/FeaturesScreen.tsx
@@ -827,7 +827,7 @@ const FONT_FAMILIES = Platform.select({
 // can't come out empty.
 type FontFamilyRow = { label: string; style: TextStyle & { fontFamily: string } };
 
-const FONT_FAMILY_RESOLUTION: FontFamilyRow[] = Platform.select({
+const PLATFORM_FONT_ROWS: FontFamilyRow[] = Platform.select({
   ios: [
     {
       // Renders in the Ultra Light cut, not a system font at weight 100.
@@ -877,10 +877,6 @@ const FONT_FAMILY_RESOLUTION: FontFamilyRow[] = Platform.select({
       label: 'Condensed face',
       style: { fontSize: 20, fontFamily: 'HelveticaNeue-CondensedBlack' },
     },
-    {
-      label: 'Unresolvable name',
-      style: { fontSize: 18, fontFamily: 'NoSuchFont-Regular' },
-    },
   ],
   default: [
     {
@@ -891,10 +887,6 @@ const FONT_FAMILY_RESOLUTION: FontFamilyRow[] = Platform.select({
     {
       label: 'Single-cut family',
       style: { fontSize: 18, fontFamily: 'cursive' },
-    },
-    {
-      label: 'Unresolvable name',
-      style: { fontSize: 18, fontFamily: 'NoSuchFont-Regular' },
     },
     {
       label: 'Condensed face',
@@ -923,11 +915,59 @@ const FONT_FAMILY_RESOLUTION: FontFamilyRow[] = Platform.select({
   ],
 });
 
+// Custom fonts, as against the platform built-ins above — and the only rows in
+// this screen that are the same on iOS and Android, because the name is ours
+// rather than the platform's. Loaded in App.tsx via expo-font, which is how most
+// apps get a custom font, and the reason this section exists: it is the case the
+// old resolution failed on hardest.
+//
+// What expo-font does on iOS, in its own words (ios/UIFont+FontFamilyAlias.swift):
+// it swizzles +fontNames(forFamilyName:) so that an unknown family name gets
+// retried as an alias, and when the alias resolves to a PostScript name that is
+// not itself a family, it answers with that one name in a one-element array.
+// So resolution reaches the face only if it goes through that method —
+// UIFontDescriptorFamilyAttribute matching does not call it, which is why every
+// row here used to come out as the system font.
+//
+// It is also why the earlier attempt at this fix, which special-cased
+// `fontNamesForFamilyName:.count == 0`, could never have worked in an Expo app:
+// the swizzle returns one name, not none.
+//
+// On Android the same aliases resolve without any of this — expo-font registers
+// them into ReactFontManager (android FontLoaderModule.kt), which is what
+// PlainTextView.applyTypeface already resolves through.
+const CUSTOM_FONT_ROWS: FontFamilyRow[] = [
+  {
+    label: 'expo-font alias',
+    style: { fontSize: 18, fontFamily: 'Inter_400Regular' },
+  },
+  {
+    // Each cut is loaded under its own alias, so weight lives in the name here
+    // rather than in fontWeight — one alias is a one-face family, and there is
+    // no sibling cut for a weight to match against.
+    label: 'expo-font alias, heavier cut',
+    style: { fontSize: 18, fontFamily: 'Inter_600SemiBold' },
+  },
+  {
+    // Slant in the name too, and for the same reason. Nothing synthesized: the
+    // face is already italic, so plainTextFont's italic round-trip is skipped.
+    label: 'expo-font alias, light italic',
+    style: { fontSize: 18, fontFamily: 'Inter_300Light_Italic' },
+  },
+];
+
+const UNRESOLVABLE_FONT_ROW: FontFamilyRow = {
+  label: 'Unresolvable name',
+  style: { fontSize: 18, fontFamily: 'NoSuchFont-Regular' },
+};
+
+const FONT_FAMILY_RESOLUTION: FontFamilyRow[] = [
+  ...PLATFORM_FONT_ROWS,
+  ...CUSTOM_FONT_ROWS,
+  UNRESOLVABLE_FONT_ROW,
+];
+
 const FONT_FAMILY_RESOLUTION_FOOTER = Platform.select({
-  ios:
-    'Compare Text should agree on every row. The last one also logs ' +
-    '"Unrecognized font family" to the console, at info level, as RN <Text> does.',
-  default:
-    'The iOS resolution these rows target has no Android counterpart, so they are ' +
-    "analogs: nearest-weight matching is the platform's own here, not ours.",
+  ios: 'Compare Text should agree on every row. Inter_* are expo-font aliases, one per cut.',
+  default: 'The built-in rows are Android analogs. Inter_* are expo-font aliases, one per cut.',
 });

--- a/example/src/screens/FeaturesScreen.tsx
+++ b/example/src/screens/FeaturesScreen.tsx
@@ -35,19 +35,7 @@ export default function FeaturesScreen({ navigation }: Props) {
           </TextItem>
         ))}
       </Section>
-      <Section title="Font Family">
-        {FONT_FAMILIES.map(({ label, fontFamily }) => (
-          <TextItem
-            key={label}
-            label={label}
-            showText={showText}
-            style={{ fontSize: SHORT_ROW_SIZE, fontFamily }}
-          >
-            {SPECIMEN_DIGITS}
-          </TextItem>
-        ))}
-      </Section>
-      <Section title="Font Family Resolution" footer={FONT_FAMILY_RESOLUTION_FOOTER}>
+      <Section title="Font Family" footer={FONT_FAMILY_RESOLUTION_FOOTER}>
         {FONT_FAMILY_RESOLUTION.map(({ label, style }) => (
           <TextItem key={label} label={label} showText={showText} style={style}>
             {style.fontFamily}
@@ -610,7 +598,6 @@ const styles = StyleSheet.create({
 // outruns every clamp in the screen without introducing a second sentence to
 // read.
 const SPECIMEN = 'Quick brown fox';
-const SPECIMEN_DIGITS = 'Quick brown fox 0123';
 const PARAGRAPH = 'The quick brown fox jumps over the lazy dog.';
 const PARAGRAPH_LONG = `${PARAGRAPH} ${PARAGRAPH} ${PARAGRAPH}`;
 
@@ -780,25 +767,8 @@ const COLORS = [
 
 const FONT_WEIGHTS = ['normal', 'bold', '100', '300', '500', '700', '900'] as const;
 
-// Font family names aren't portable across platforms, so pick the equivalent
-// built-in for each — mirrors how RN's own <Text> docs demo fontFamily.
-const FONT_FAMILIES = Platform.select({
-  ios: [
-    { label: 'System', fontFamily: undefined },
-    { label: 'Georgia', fontFamily: 'Georgia' },
-    { label: 'Menlo', fontFamily: 'Menlo' },
-    { label: 'Courier', fontFamily: 'Courier' },
-  ],
-  default: [
-    { label: 'System', fontFamily: undefined },
-    { label: 'serif', fontFamily: 'serif' },
-    { label: 'monospace', fontFamily: 'monospace' },
-    { label: 'sans-serif-condensed', fontFamily: 'sans-serif-condensed' },
-  ],
-});
-
-// The rows above take family names that resolve the easy way. These take the
-// ones that don't, a row per branch of the iOS resolution in
+// The first rows are plain registered family names, which resolve the easy way.
+// The rest take the names that don't, a row per branch of the iOS resolution in
 // ios/PlainTextFont.mm: weight matching inside a family, a family carrying a
 // single cut, a name that is neither family nor face, a face the family path
 // can't reach, a weight met by a real cut, the same cut named outright, a slant
@@ -829,6 +799,12 @@ type FontFamilyRow = { label: string; style: TextStyle & { fontFamily: string } 
 
 const PLATFORM_FONT_ROWS: FontFamilyRow[] = Platform.select({
   ios: [
+    // The straightforward ones first: a registered family name, which is the
+    // only thing the resolution this section exercises never had trouble with.
+    { label: 'System', style: { fontSize: 18, fontFamily: 'System' } },
+    { label: 'Georgia', style: { fontSize: 18, fontFamily: 'Georgia' } },
+    { label: 'Menlo', style: { fontSize: 18, fontFamily: 'Menlo' } },
+    { label: 'Courier', style: { fontSize: 18, fontFamily: 'Courier' } },
     {
       // Renders in the Ultra Light cut, not a system font at weight 100.
       label: 'Family and weight',
@@ -879,6 +855,13 @@ const PLATFORM_FONT_ROWS: FontFamilyRow[] = Platform.select({
     },
   ],
   default: [
+    { label: 'System', style: { fontSize: 18, fontFamily: 'System' } },
+    { label: 'serif', style: { fontSize: 18, fontFamily: 'serif' } },
+    { label: 'monospace', style: { fontSize: 18, fontFamily: 'monospace' } },
+    {
+      label: 'sans-serif-condensed',
+      style: { fontSize: 18, fontFamily: 'sans-serif-condensed' },
+    },
     {
       // Renders in the Thin cut.
       label: 'Family and weight',

--- a/example/src/screens/FeaturesScreen.tsx
+++ b/example/src/screens/FeaturesScreen.tsx
@@ -47,6 +47,13 @@ export default function FeaturesScreen({ navigation }: Props) {
           </TextItem>
         ))}
       </Section>
+      <Section title="Font Family Resolution" footer={FONT_FAMILY_RESOLUTION_FOOTER}>
+        {FONT_FAMILY_RESOLUTION.map(({ label, style }) => (
+          <TextItem key={label} label={label} showText={showText} style={style}>
+            {style.fontFamily}
+          </TextItem>
+        ))}
+      </Section>
       <Section title="Color">
         {COLORS.map(({ label, color }) => (
           <TextItem
@@ -788,4 +795,139 @@ const FONT_FAMILIES = Platform.select({
     { label: 'monospace', fontFamily: 'monospace' },
     { label: 'sans-serif-condensed', fontFamily: 'sans-serif-condensed' },
   ],
+});
+
+// The rows above take family names that resolve the easy way. These take the
+// ones that don't, a row per branch of the iOS resolution in
+// ios/PlainTextFont.mm: weight matching inside a family, a family carrying a
+// single cut, a name that is neither family nor face, a face the family path
+// can't reach, a weight met by a real cut, the same cut named outright, a slant
+// met by none, and a face name.
+//
+// Every face and family here is verified present in the iOS 26.5 simulator
+// runtime, and the PostScript names are read from its font files rather than
+// guessed. A name that isn't installed renders as the system font — which is
+// what the Unresolvable row is for, so a wrong name elsewhere would quietly read
+// as a passing row.
+//
+// The Face name and Unresolvable rows are the pair worth watching together.
+// Resolution used to match UIFontDescriptorFamilyAttribute, which takes a
+// registered family name and nothing else, so a face name silently produced the
+// system font — the very thing an unresolvable name produces, which is what made
+// the bug hard to see: a loaded custom font and a typo rendered identically.
+// They should look different now, and both should match the brass <Text> overlay.
+//
+// Android resolves fontFamily through Typeface family names, with no PostScript
+// names and no weight matching to do, so its rows are the nearest analogs rather
+// than the same cases.
+
+// Each row renders its own fontFamily value as its content, so what you read is
+// what was passed. There is no second copy of the name to fall out of step with
+// the style, and fontFamily is required rather than optional so the content
+// can't come out empty.
+type FontFamilyRow = { label: string; style: TextStyle & { fontFamily: string } };
+
+const FONT_FAMILY_RESOLUTION: FontFamilyRow[] = Platform.select({
+  ios: [
+    {
+      // Renders in the Ultra Light cut, not a system font at weight 100.
+      label: 'Family and weight',
+      style: { fontSize: 20, fontFamily: 'Avenir Next', fontWeight: '100' },
+    },
+    {
+      // One cut in the family, so the bold has nothing to resolve to and must
+      // leave the row in Zapfino rather than fall back.
+      label: 'Single-cut family',
+      style: { fontSize: 16, fontFamily: 'Zapfino', fontWeight: 'bold' },
+    },
+    {
+      // HelveticaNeue-Thin, picked because RCTGetFontWeight reads the name suffix
+      // — a weight trait alone would not have singled it out. Also the order in
+      // that suffix list earning its keep: the family carries UltraLight, Thin
+      // and Light, and "ultralight" has to be tested before "light" or the
+      // UltraLight face would answer to weight 300.
+      label: 'Weight with a real cut',
+      style: { fontSize: 20, fontFamily: 'Helvetica Neue', fontWeight: '200' },
+    },
+    {
+      // The same cut, asked for by name instead of by weight. Renders identically
+      // to the row above, by a different branch: no family matches this string, so
+      // it resolves as a face.
+      label: 'Weight suffix in the name',
+      style: { fontSize: 20, fontFamily: 'HelveticaNeue-Thin' },
+    },
+    {
+      // Copperplate ships Regular, Light and Bold, and no italic. So the slant
+      // filter rejects every cut, the first face is taken instead, and the slant
+      // on top of it is synthesized. Contrast with the Georgia row, which has a
+      // real italic to find.
+      label: 'Slant with no cut',
+      style: { fontSize: 24, fontFamily: 'Copperplate', fontStyle: 'italic' },
+    },
+    {
+      // A face carries its own slant, so fontStyle stays out of this row:
+      // nothing in it is synthesized.
+      label: 'Face name',
+      style: { fontSize: 20, fontFamily: 'Georgia-BoldItalic' },
+    },
+    {
+      // Both Condensed cuts sit in family "Helvetica Neue", but the family path
+      // filters condensed faces out, so no weight reaches them there — a face
+      // name is the only way in. The two branches are not interchangeable.
+      label: 'Condensed face',
+      style: { fontSize: 20, fontFamily: 'HelveticaNeue-CondensedBlack' },
+    },
+    {
+      label: 'Unresolvable name',
+      style: { fontSize: 18, fontFamily: 'NoSuchFont-Regular' },
+    },
+  ],
+  default: [
+    {
+      // Renders in the Thin cut.
+      label: 'Family and weight',
+      style: { fontSize: 18, fontFamily: 'sans-serif', fontWeight: '100' },
+    },
+    {
+      label: 'Single-cut family',
+      style: { fontSize: 18, fontFamily: 'cursive' },
+    },
+    {
+      label: 'Unresolvable name',
+      style: { fontSize: 18, fontFamily: 'NoSuchFont-Regular' },
+    },
+    {
+      label: 'Condensed face',
+      style: { fontSize: 18, fontFamily: 'sans-serif-condensed-light' },
+    },
+    {
+      // Light rather than Thin, so this pair stays distinguishable from the
+      // family-and-weight row above.
+      label: 'Weight with a real cut',
+      style: { fontSize: 18, fontFamily: 'sans-serif', fontWeight: '300' },
+    },
+    {
+      label: 'Weight suffix in the name',
+      style: { fontSize: 18, fontFamily: 'sans-serif-light' },
+    },
+    {
+      // Android synthesizes the slant here too, for the same reason: the family
+      // carries no italic cut.
+      label: 'Slant with no cut',
+      style: { fontSize: 18, fontFamily: 'monospace', fontStyle: 'italic' },
+    },
+    {
+      label: 'Named cut',
+      style: { fontSize: 18, fontFamily: 'sans-serif-medium' },
+    },
+  ],
+});
+
+const FONT_FAMILY_RESOLUTION_FOOTER = Platform.select({
+  ios:
+    'Compare Text should agree on every row. The last one also logs ' +
+    '"Unrecognized font family" to the console, at info level, as RN <Text> does.',
+  default:
+    'The iOS resolution these rows target has no Android counterpart, so they are ' +
+    "analogs: nearest-weight matching is the platform's own here, not ours.",
 });

--- a/ios/PlainTextFont.h
+++ b/ios/PlainTextFont.h
@@ -9,9 +9,15 @@
  *
  * It is also a hot path: every commit resolves a font per node on the shadow
  * thread and again on the main thread. Resolution is not free — a custom
- * fontFamily matches against the system font database, and italic costs a
- * second descriptor round-trip — so the results are cached, as RN does for its
- * own system fonts (RCTFont.mm, `cachedSystemFont`).
+ * fontFamily is matched face by face against the family's fonts, and italic
+ * costs a second descriptor round-trip — so the results are cached, as RN does
+ * for its own system fonts (RCTFont.mm, `cachedSystemFont`).
+ *
+ * Three caches, because the three questions expire at different rates: the
+ * family's face names per family, the winning face per family/weight/style, and
+ * the UIFont per those plus size and variants. Only the last depends on
+ * fontSize, so a new size costs one font instantiation rather than another scan
+ * of the family. All three clear on `kCTFontManagerRegisteredFontsChangedNotification`.
  */
 
 #pragma once
@@ -34,8 +40,24 @@ namespace facebook::react {
 CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseMultiplier);
 
 /*
+ * `fontSize` scaled by `fontSizeMultiplier` — the value to pass to
+ * `plainTextFont`, and the one to derive anything else that must line up with
+ * the font's own size from.
+ *
+ * Rounded to whole points when a multiplier actually applies, exactly as
+ * RCTFont.mm rounds it, so a Dynamic Type setting lands on the same size RN's
+ * <Text> uses. An unscaled fontSize is left alone, also as in RCTFont.mm, so a
+ * fractional fontSize prop keeps its fraction.
+ *
+ * SYNC: both callers must scale through this, or one measures at a size the
+ * other doesn't draw at. lineHeight is not rounded (RN doesn't round it either)
+ * and is scaled by the multiplier directly.
+ */
+CGFloat plainTextScaledFontSize(CGFloat fontSize, CGFloat fontSizeMultiplier);
+
+/*
  * The UIFont for these props at `fontSize`, which the caller has already scaled
- * by `plainTextFontSizeMultiplier`. Cached, keyed on the only six inputs that
+ * through `plainTextScaledFontSize`. Cached, keyed on the only six inputs that
  * reach UIFont: fontFamily, fontSize, fontWeight, italic, fontVariant and
  * fontVariationSettings.
  *

--- a/ios/PlainTextFont.h
+++ b/ios/PlainTextFont.h
@@ -13,11 +13,11 @@
  * costs a second descriptor round-trip — so the results are cached, as RN does
  * for its own system fonts (RCTFont.mm, `cachedSystemFont`).
  *
- * Three caches, because the three questions expire at different rates: the
- * family's face names per family, the winning face per family/weight/style, and
- * the UIFont per those plus size and variants. Only the last depends on
- * fontSize, so a new size costs one font instantiation rather than another scan
- * of the family. All three clear on `kCTFontManagerRegisteredFontsChangedNotification`.
+ * Three caches, since only one of the three questions depends on fontSize: the
+ * family's face names, the winning face per family/weight/style, and the UIFont
+ * per those plus size and variants. So a new size costs one font instantiation
+ * rather than another scan of the family. All three clear on
+ * `kCTFontManagerRegisteredFontsChangedNotification`.
  */
 
 #pragma once
@@ -40,26 +40,15 @@ namespace facebook::react {
 CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseMultiplier);
 
 /*
- * `fontSize` scaled by `fontSizeMultiplier` — the value to pass to
- * `plainTextFont`, and the one to derive anything else that must line up with
- * the font's own size from.
- *
- * Rounded to whole points when a multiplier actually applies, exactly as
- * RCTFont.mm rounds it, so a Dynamic Type setting lands on the same size RN's
- * <Text> uses. An unscaled fontSize is left alone, also as in RCTFont.mm, so a
- * fractional fontSize prop keeps its fraction.
- *
- * SYNC: both callers must scale through this, or one measures at a size the
- * other doesn't draw at. lineHeight is not rounded (RN doesn't round it either)
- * and is scaled by the multiplier directly.
- */
-CGFloat plainTextScaledFontSize(CGFloat fontSize, CGFloat fontSizeMultiplier);
-
-/*
- * The UIFont for these props at `fontSize`, which the caller has already scaled
- * through `plainTextScaledFontSize`. Cached, keyed on the only six inputs that
- * reach UIFont: fontFamily, fontSize, fontWeight, italic, fontVariant and
+ * The UIFont for these props, at `props.fontSize` scaled by the multiplier from
+ * `plainTextFontSizeMultiplier`. Cached, keyed on the only six inputs that reach
+ * UIFont: fontFamily, fontSize, fontWeight, italic, fontVariant and
  * fontVariationSettings.
+ *
+ * Takes the multiplier rather than an already-scaled size so that the rounding
+ * RCTFont.mm applies to it lives in one place instead of in both callers. Nothing
+ * else needs the scaled size: the font carries it, and lineHeight scales by the
+ * multiplier without rounding (RN's behavior too) in each caller.
  *
  * Never nil: an unresolvable fontFamily falls back to the system font, since
  * both callers would otherwise silently measure and draw with different
@@ -68,6 +57,6 @@ CGFloat plainTextScaledFontSize(CGFloat fontSize, CGFloat fontSizeMultiplier);
  * Callable from any thread: UIFont and NSCache are both thread-safe, so the
  * shadow thread and the main thread share one cache.
  */
-UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSize);
+UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier);
 
 } // namespace facebook::react

--- a/ios/PlainTextFont.h
+++ b/ios/PlainTextFont.h
@@ -39,6 +39,10 @@ CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseM
  * reach UIFont: fontFamily, fontSize, fontWeight, italic, fontVariant and
  * fontVariationSettings.
  *
+ * Never nil: an unresolvable fontFamily falls back to the system font, since
+ * both callers would otherwise silently measure and draw with different
+ * defaults.
+ *
  * Callable from any thread: UIFont and NSCache are both thread-safe, so the
  * shadow thread and the main thread share one cache.
  */

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -23,11 +23,8 @@ namespace facebook::react {
 // ("OpenRunde-Bold") never produces a list, and would ask on every lookup.
 static NSArray<NSString *> *cachedFontNamesForFamilyName(NSString *familyName)
 {
-  static PlainTextFontCache<NSString *, NSArray<NSString *> *> *familyNamesCache;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    familyNamesCache = [[PlainTextFontCache alloc] initWithCountLimit:0];
-  });
+  static PlainTextFontCache<NSString *, NSArray<NSString *> *> *familyNamesCache =
+      [[PlainTextFontCache alloc] initWithCountLimit:0];
 
   return [familyNamesCache objectForKey:familyName
                                    orSet:^NSArray<NSString *> * {
@@ -204,11 +201,8 @@ static constexpr NSUInteger kFontCacheCountLimit = 256;
 
 static PlainTextFontCache<NSString *, UIFont *> *fontCache()
 {
-  static PlainTextFontCache<NSString *, UIFont *> *resolvedFontsCache;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    resolvedFontsCache = [[PlainTextFontCache alloc] initWithCountLimit:kFontCacheCountLimit];
-  });
+  static PlainTextFontCache<NSString *, UIFont *> *resolvedFontsCache =
+      [[PlainTextFontCache alloc] initWithCountLimit:kFontCacheCountLimit];
   return resolvedFontsCache;
 }
 
@@ -285,11 +279,8 @@ static NSString *resolvedFaceName(
     RCTFontWeight fontWeight,
     BOOL isItalic)
 {
-  static PlainTextFontCache<NSString *, NSString *> *faceNamesCache;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    faceNamesCache = [[PlainTextFontCache alloc] initWithCountLimit:0];
-  });
+  static PlainTextFontCache<NSString *, NSString *> *faceNamesCache =
+      [[PlainTextFontCache alloc] initWithCountLimit:0];
 
   NSString *key = [NSString stringWithUTF8String:faceKey.c_str()];
   if (key == nil) {
@@ -297,8 +288,8 @@ static NSString *resolvedFaceName(
   }
   return [faceNamesCache objectForKey:key
                                  orSet:^NSString * {
-                          return computeFaceName(fontFamily, fontWeightProp, fontWeight, isItalic);
-                        }];
+                                   return computeFaceName(fontFamily, fontWeightProp, fontWeight, isItalic);
+                                 }];
 }
 
 CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseMultiplier)

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -246,11 +246,22 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSize)
   UIFontWeight weight = fontWeightFromProp(props.fontWeight);
   if (!props.fontFamily.empty()) {
     NSString *fontFamily = [NSString stringWithUTF8String:props.fontFamily.c_str()];
-    UIFontDescriptor *descriptor = [UIFontDescriptor fontDescriptorWithFontAttributes:@{
-      UIFontDescriptorFamilyAttribute : fontFamily,
-      UIFontDescriptorTraitsAttribute : @{UIFontWeightTrait : @(weight)},
-    }];
-    font = [UIFont fontWithDescriptor:descriptor size:fontSize];
+    // Resolve via the family's font names, as RCTFont.mm does: fontFamily is
+    // usually a face/PostScript name ("OpenRunde-Bold" in family "Open Runde")
+    // or an expo-font alias, and UIFontDescriptorFamilyAttribute matches neither.
+    // A single name is a face, which already picks the cut, so it skips weight.
+    NSArray<NSString *> *fontNames = [UIFont fontNamesForFamilyName:fontFamily];
+    if (fontNames.count == 0) {
+      font = [UIFont fontWithName:fontFamily size:fontSize];
+    } else if (fontNames.count == 1) {
+      font = [UIFont fontWithName:fontNames.firstObject size:fontSize];
+    } else {
+      UIFontDescriptor *descriptor = [UIFontDescriptor fontDescriptorWithFontAttributes:@{
+        UIFontDescriptorFamilyAttribute : fontFamily,
+        UIFontDescriptorTraitsAttribute : @{UIFontWeightTrait : @(weight)},
+      }];
+      font = [UIFont fontWithDescriptor:descriptor size:fontSize];
+    }
   } else {
     font = [UIFont systemFontOfSize:fontSize weight:weight];
   }

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -104,6 +104,10 @@ static NSString *closestFaceNameInFamily(
 
   NSString *name = nil;
 
+  // EXPENSIVE: instantiates a UIFont, queries two symbolic traits and computes a
+  // weight for every candidate face — scales with family size. Not per node:
+  // resolvedFaceName caches the result per family/weight/style, so this only runs
+  // on a cache miss.
   // Get the closest font that matches the given weight for the fontFamily
   CGFloat closestWeight = INFINITY;
   for (NSString *candidate in names) {

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -36,10 +36,9 @@ static UIFontWeight fontWeightFromProp(const std::string &fontWeight)
   return weight != nil ? (UIFontWeight)weight.doubleValue : UIFontWeightRegular;
 }
 
-// Every cache in this file answers a question about the installed fonts, so
-// registering a font at runtime (expo-font, CTFontManagerRegisterFontsForURL)
-// invalidates all of them — in particular any entry that resolved while the
-// family was still unknown, which would otherwise outlive the registration.
+// Registering a font at runtime (expo-font, CTFontManagerRegisterFontsForURL)
+// changes what a fontFamily resolves to, so every cache here is stale after it —
+// in particular an entry that resolved while the family was still unknown.
 // RCTFont.mm clears its own family-name cache on the same notification.
 static void clearOnFontRegistration(NSCache *cache)
 {
@@ -53,9 +52,9 @@ static void clearOnFontRegistration(NSCache *cache)
 }
 
 // Caching wrapper around +[UIFont fontNamesForFamilyName:], which enumerates the
-// font database — RCTFont.mm calls it expensive and wraps it the same way. Worth
-// caching the empty answer too: a fontFamily naming a face rather than a family
-// ("OpenRunde-Bold") reaches this on every lookup and never produces a list.
+// font database — RCTFont.mm calls it expensive and wraps it the same way. The
+// empty answer is cached too: a fontFamily naming a face rather than a family
+// ("OpenRunde-Bold") never produces a list, and would ask on every lookup.
 static NSArray<NSString *> *cachedFontNamesForFamilyName(NSString *familyName)
 {
   static NSCache<NSString *, NSArray<NSString *> *> *cache;
@@ -97,12 +96,10 @@ static BOOL isCondensedFont(UIFont *font)
   return (CTFontGetSymbolicTraits((CTFontRef)font) & kCTFontTraitCondensed) != 0;
 }
 
-// The size the faces are instantiated at while being compared. Every input the
-// comparison reads — the PostScript name RCTGetFontWeight matches suffixes
-// against, the symbolic traits, the weight trait — is a property of the face, not
-// of the size it was asked for, so which face wins is size-independent. That is
-// what lets the result be cached once per family/weight/slant instead of once per
-// size as well.
+// Everything the comparison below reads — the PostScript name, the symbolic
+// traits, the weight trait — belongs to the face rather than to the size it was
+// asked for, so the faces can be compared at any size and the winner cached
+// without one.
 static constexpr CGFloat kFaceProbeFontSize = 12;
 
 /*
@@ -115,9 +112,9 @@ static constexpr CGFloat kFaceProbeFontSize = 12;
  *     after its system-font special case, which this function is never reached
  *     for — an empty fontFamily takes the systemFontOfSize: path in
  *     plainTextFont instead.
- *   - `isCondensed` is a local NO rather than a parameter. RN derives it from
- *     the UIFont it is updating in place and from the "SystemCondensed" family
- *     name; this library has neither, so RN's value is constant NO here.
+ *   - RN's `isCondensed` is inlined as NO. It derives the value from the UIFont
+ *     it is updating in place and from the "SystemCondensed" family name; this
+ *     library has neither.
  *   - RN keeps the winning UIFont; this keeps its name, and the caller
  *     instantiates it at the size actually wanted.
  *
@@ -133,29 +130,25 @@ static NSString *closestFaceNameInFamily(NSArray<NSString *> *names, RCTFontWeig
     return nil;
   }
 
-  // A single-face family is the answer either way — the loop below picks it if it
-  // matches the requested traits, and the "at least return the first font"
-  // fallback picks the same one if it doesn't. Taking it here skips instantiating
-  // the face and querying its traits and weight, which is the whole cost of the
-  // scan. This is the common shape for a custom or expo-registered font.
+  // One face is the answer either way: the loop picks it if it matches, and the
+  // fallback below picks it if it doesn't. Skipping the loop skips the whole cost
+  // of the scan, and one face is the usual shape of a custom or expo font.
   if (names.count == 1) {
     return names[0];
   }
 
-  BOOL isCondensed = NO;
   NSString *name = nil;
 
   // Get the closest font that matches the given weight for the fontFamily
   CGFloat closestWeight = INFINITY;
   for (NSString *candidate in names) {
     UIFont *match = [UIFont fontWithName:candidate size:kFaceProbeFontSize];
-    // RN doesn't guard this, having no reason to expect a name the family itself
-    // just reported to be unloadable. Guarded here only because the trait calls
-    // below take a CTFontRef, where nil is a crash rather than a nil result.
+    // Guarded, unlike RN, only because the trait calls take a CTFontRef, where
+    // nil crashes rather than returning nil.
     if (match == nil) {
       continue;
     }
-    if (isItalic == isItalicFont(match) && isCondensed == isCondensedFont(match)) {
+    if (isItalic == isItalicFont(match) && !isCondensedFont(match)) {
       CGFloat testWeight = RCTGetFontWeight(match);
       if (ABS(testWeight - fontWeight) < ABS(closestWeight - fontWeight)) {
         name = candidate;
@@ -322,13 +315,11 @@ static NSString *fontCacheKey(
   return [NSString stringWithUTF8String:key.c_str()];
 }
 
-// One entry per distinct font key, and the key carries two continuous inputs —
-// fontSize, and any axis in fontVariationSettings — so the number of live entries
-// follows how many sizes and instances the app renders. Bounded so that an app
-// animating or otherwise sweeping either one can't grow it without limit; NSCache's
-// own eviction is driven by memory pressure, which arrives late and then drops
-// everything at once — the refill for that is what the face cache below makes
-// cheap. Well above any real type scale, times weights, styles and variants.
+// The key carries two continuous inputs — fontSize, and any axis in
+// fontVariationSettings — so an app animating or otherwise sweeping either would
+// grow this cache without limit; NSCache's own eviction only arrives with memory
+// pressure, and then drops everything. Well above any real type scale, times
+// weights, styles and variants.
 static constexpr NSUInteger kFontCacheCountLimit = 256;
 
 static NSCache<NSString *, UIFont *> *fontCache()
@@ -343,20 +334,18 @@ static NSCache<NSString *, UIFont *> *fontCache()
   return cache;
 }
 
-// Stored in place of a face name for a fontFamily that names neither a known
-// family nor a known face. NSCache can't hold nil, and re-deriving "still
-// unresolvable" means re-enumerating the font database and re-logging, once per
-// size, for as long as the typo is on screen.
+// Cached in place of a face name for a fontFamily that names neither a known
+// family nor a known face, since NSCache can't hold nil and re-deriving "still
+// unresolvable" costs a walk of the font database and another log line.
 static NSString *const kUnresolvableFace = @"";
 
 /*
  * The face name to instantiate for this fontFamily, or nil if it resolves to
  * nothing and the caller should fall back to the system font.
  *
- * Cached separately from the font itself because the answer doesn't depend on
- * fontSize (see kFaceProbeFontSize): without this, every new size re-ran the
- * family scan — N font instantiations, 2N symbolic-trait queries and N
- * RCTGetFontWeight calls — to arrive at the name it already knew.
+ * Cached apart from the font itself because the answer doesn't depend on fontSize
+ * (see kFaceProbeFontSize), so a new size costs one font instantiation instead of
+ * another scan of the family.
  */
 static NSString *resolvedFaceName(
     const std::string &fontFamily,
@@ -391,9 +380,7 @@ static NSString *resolvedFaceName(
       } else {
         // Same message and same level as RCTFont.mm, from the same branch, so a
         // typo reads identically whether it hit <PlainText> or <Text>. Info
-        // rather than warn keeps it out of LogBox, which is RN's call, not ours
-        // — the substitution is cosmetic, and this now fires once per distinct
-        // family/weight/style rather than once per size on top of that.
+        // rather than warn keeps it out of LogBox, which is RN's call, not ours.
         RCTLogInfo(@"Unrecognized font family '%@'", familyName);
       }
     }
@@ -416,7 +403,10 @@ CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseM
   return baseMultiplier;
 }
 
-CGFloat plainTextScaledFontSize(CGFloat fontSize, CGFloat fontSizeMultiplier)
+// Rounded to whole points when a multiplier applies and left alone when none
+// does, both as in RCTFont.mm — so a Dynamic Type setting lands on the same size
+// RN's <Text> uses, and a fractional fontSize prop keeps its fraction.
+static CGFloat scaledFontSize(CGFloat fontSize, CGFloat fontSizeMultiplier)
 {
   if (fontSizeMultiplier <= 0.0 || fontSizeMultiplier == 1.0) {
     return fontSize;
@@ -424,8 +414,9 @@ CGFloat plainTextScaledFontSize(CGFloat fontSize, CGFloat fontSizeMultiplier)
   return std::round(fontSize * fontSizeMultiplier);
 }
 
-UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSize)
+UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
 {
+  CGFloat fontSize = scaledFontSize(props.fontSize, fontSizeMultiplier);
   bool italic = props.fontStyle == RNPlainTextFontStyle::Italic;
   std::string faceKey = faceCacheKey(props.fontFamily, props.fontWeight, italic);
   NSString *key = fontCacheKey(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -112,9 +112,11 @@ static constexpr CGFloat kFaceProbeFontSize = 12;
  *     after its system-font special case, which this function is never reached
  *     for — an empty fontFamily takes the systemFontOfSize: path in
  *     plainTextFont instead.
- *   - RN's `isCondensed` is inlined as NO. It derives the value from the UIFont
- *     it is updating in place and from the "SystemCondensed" family name; this
- *     library has neither.
+ *   - `isCondensed` is a parameter rather than derived from a "SystemCondensed"
+ *     family name, which this library has no equivalent of. The top-level
+ *     family lookup in resolvedFaceName passes NO, matching RN's own default
+ *     for a fresh (font == nil) update; the face-name fallback below passes
+ *     the matched face's actual trait, as RN derives it from that same face.
  *   - RN keeps the winning UIFont; this keeps its name, and the caller
  *     instantiates it at the size actually wanted.
  *
@@ -124,7 +126,11 @@ static constexpr CGFloat kFaceProbeFontSize = 12;
  * descriptor resolves to the system font instead of failing — the silent
  * fallback this whole path exists to avoid.
  */
-static NSString *closestFaceNameInFamily(NSArray<NSString *> *names, RCTFontWeight fontWeight, BOOL isItalic)
+static NSString *closestFaceNameInFamily(
+    NSArray<NSString *> *names,
+    RCTFontWeight fontWeight,
+    BOOL isItalic,
+    BOOL isCondensed)
 {
   if (names.count == 0) {
     return nil;
@@ -148,7 +154,7 @@ static NSString *closestFaceNameInFamily(NSArray<NSString *> *names, RCTFontWeig
     if (match == nil) {
       continue;
     }
-    if (isItalic == isItalicFont(match) && !isCondensedFont(match)) {
+    if (isItalic == isItalicFont(match) && isCondensed == isCondensedFont(match)) {
       CGFloat testWeight = RCTGetFontWeight(match);
       if (ABS(testWeight - fontWeight) < ABS(closestWeight - fontWeight)) {
         name = candidate;
@@ -346,10 +352,17 @@ static NSString *const kUnresolvableFace = @"";
  * Cached apart from the font itself because the answer doesn't depend on fontSize
  * (see kFaceProbeFontSize), so a new size costs one font instantiation instead of
  * another scan of the family.
+ *
+ * `fontWeightProp` is the raw prop string, not just the weight it maps to: an
+ * empty string is RN's own signal that fontWeight wasn't set (RCTFont.mm reads
+ * it from a possibly-nil JSON value), and the face-name fallback below needs
+ * that signal to know whether to keep the caller's weight or take the matched
+ * face's own.
  */
 static NSString *resolvedFaceName(
     const std::string &fontFamily,
     const std::string &faceKey,
+    const std::string &fontWeightProp,
     RCTFontWeight fontWeight,
     BOOL isItalic)
 {
@@ -369,14 +382,36 @@ static NSString *resolvedFaceName(
   NSString *familyName = [NSString stringWithUTF8String:fontFamily.c_str()];
   NSString *faceName = nil;
   if (familyName != nil) {
-    faceName = closestFaceNameInFamily(cachedFontNamesForFamilyName(familyName), fontWeight, isItalic);
+    faceName = closestFaceNameInFamily(cachedFontNamesForFamilyName(familyName), fontWeight, isItalic, NO);
     if (faceName == nil) {
       // Not a registered family, so take it for the face / PostScript name it
       // probably is ("OpenRunde-Bold" rather than "Open Runde"). An expo-font
       // alias lands in the branch above instead: the swizzled
       // +fontNamesForFamilyName: answers it with a one-element array.
-      if ([UIFont fontWithName:familyName size:kFaceProbeFontSize] != nil) {
-        faceName = familyName;
+      UIFont *namedFont = [UIFont fontWithName:familyName size:kFaceProbeFontSize];
+      if (namedFont != nil) {
+        // RN doesn't stop here either ("we'll do what was meant, not what was
+        // said"): it re-derives the real family from this face and searches
+        // that family for the closest match to what the props actually ask
+        // for, so "Georgia-Bold" + fontStyle: "italic" lands on the family's
+        // real BoldItalic face instead of a synthesized slant on Georgia-Bold.
+        //
+        // A prop that wasn't set inherits the matched face's own trait rather
+        // than a hardcoded default, exactly as RCTFont.mm's `style ? isItalic
+        // : isItalicFont(font)` / `weight ? fontWeight : RCTGetFontWeight(font)`
+        // do — isItalic has no "unset" of its own to check (fontStyle's
+        // codegen default collapses "not passed" and "normal" into the same
+        // enum value, see PlainTextViewNativeComponent.ts), so a caller-true
+        // isItalic wins and a caller-false one falls through to the face.
+        NSString *realFamilyName = namedFont.familyName;
+        BOOL faceIsItalic = isItalicFont(namedFont);
+        BOOL faceIsCondensed = isCondensedFont(namedFont);
+        RCTFontWeight faceWeight = RCTGetFontWeight(namedFont);
+        BOOL effectiveIsItalic = isItalic || faceIsItalic;
+        RCTFontWeight effectiveWeight = fontWeightProp.empty() ? faceWeight : fontWeight;
+        faceName = closestFaceNameInFamily(
+                       cachedFontNamesForFamilyName(realFamilyName), effectiveWeight, effectiveIsItalic, faceIsCondensed)
+            ?: familyName;
       } else {
         // Same message and same level as RCTFont.mm, from the same branch, so a
         // typo reads identically whether it hit <PlainText> or <Text>. Info
@@ -433,7 +468,7 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
   // sent through the family lookup below, where no family is actually
   // registered as "System" and it would only fail and log.
   if (!props.fontFamily.empty() && props.fontFamily != "System") {
-    NSString *faceName = resolvedFaceName(props.fontFamily, faceKey, weight, italic);
+    NSString *faceName = resolvedFaceName(props.fontFamily, faceKey, props.fontWeight, weight, italic);
     if (faceName != nil) {
       font = [UIFont fontWithName:faceName size:fontSize];
     }

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -285,7 +285,7 @@ CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseM
 // callers would otherwise silently measure and draw with different defaults.
 static UIFont *resolvedFont(const RNPlainTextProps &props, const std::string &faceKey, CGFloat fontSize, bool italic)
 {
-  UIFontWeight weight = fontWeightFromProp(props.fontWeight);
+  RCTFontWeight weight = fontWeightFromProp(props.fontWeight);
   UIFont *font = nil;
   // "System" is RCTFont.mm's own special case for the system font by name
   // (RN's <Text> accepts it the same way), so it's excluded here rather than

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -36,6 +36,43 @@ static UIFontWeight fontWeightFromProp(const std::string &fontWeight)
   return weight != nil ? (UIFontWeight)weight.doubleValue : UIFontWeightRegular;
 }
 
+// Every cache in this file answers a question about the installed fonts, so
+// registering a font at runtime (expo-font, CTFontManagerRegisterFontsForURL)
+// invalidates all of them — in particular any entry that resolved while the
+// family was still unknown, which would otherwise outlive the registration.
+// RCTFont.mm clears its own family-name cache on the same notification.
+static void clearOnFontRegistration(NSCache *cache)
+{
+  [NSNotificationCenter.defaultCenter
+      addObserverForName:(NSNotificationName)kCTFontManagerRegisteredFontsChangedNotification
+                  object:nil
+                   queue:nil
+              usingBlock:^(NSNotification *) {
+                [cache removeAllObjects];
+              }];
+}
+
+// Caching wrapper around +[UIFont fontNamesForFamilyName:], which enumerates the
+// font database — RCTFont.mm calls it expensive and wraps it the same way. Worth
+// caching the empty answer too: a fontFamily naming a face rather than a family
+// ("OpenRunde-Bold") reaches this on every lookup and never produces a list.
+static NSArray<NSString *> *cachedFontNamesForFamilyName(NSString *familyName)
+{
+  static NSCache<NSString *, NSArray<NSString *> *> *cache;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    cache = [NSCache new];
+    clearOnFontRegistration(cache);
+  });
+
+  NSArray<NSString *> *names = [cache objectForKey:familyName];
+  if (names == nil) {
+    names = [UIFont fontNamesForFamilyName:familyName] ?: @[];
+    [cache setObject:names forKey:familyName];
+  }
+  return names;
+}
+
 /*
  * Face selection within a font family, taken from React Native's own
  * RCTFont.mm, so that a custom fontFamily resolves to exactly the face RN's
@@ -60,8 +97,17 @@ static BOOL isCondensedFont(UIFont *font)
   return (CTFontGetSymbolicTraits((CTFontRef)font) & kCTFontTraitCondensed) != 0;
 }
 
+// The size the faces are instantiated at while being compared. Every input the
+// comparison reads — the PostScript name RCTGetFontWeight matches suffixes
+// against, the symbolic traits, the weight trait — is a property of the face, not
+// of the size it was asked for, so which face wins is size-independent. That is
+// what lets the result be cached once per family/weight/slant instead of once per
+// size as well.
+static constexpr CGFloat kFaceProbeFontSize = 12;
+
 /*
- * The face in this family closest to the requested weight and slant.
+ * The PostScript name of the face in this family closest to the requested weight
+ * and slant, or nil if the family has no faces at all.
  *
  * Based on: https://github.com/facebook/react-native/blob/main/packages/react-native/React/Views/RCTFont.mm
  *
@@ -72,6 +118,8 @@ static BOOL isCondensedFont(UIFont *font)
  *   - `isCondensed` is a local NO rather than a parameter. RN derives it from
  *     the UIFont it is updating in place and from the "SystemCondensed" family
  *     name; this library has neither, so RN's value is constant NO here.
+ *   - RN keeps the winning UIFont; this keeps its name, and the caller
+ *     instantiates it at the size actually wanted.
  *
  * Deliberately not UIFontDescriptorFamilyAttribute + UIFontWeightTrait, which
  * is what this replaced: descriptor matching leans on the very weight trait
@@ -79,20 +127,38 @@ static BOOL isCondensedFont(UIFont *font)
  * descriptor resolves to the system font instead of failing — the silent
  * fallback this whole path exists to avoid.
  */
-static UIFont *
-closestFaceInFamily(NSArray<NSString *> *names, CGFloat fontSize, RCTFontWeight fontWeight, BOOL isItalic)
+static NSString *closestFaceNameInFamily(NSArray<NSString *> *names, RCTFontWeight fontWeight, BOOL isItalic)
 {
+  if (names.count == 0) {
+    return nil;
+  }
+
+  // A single-face family is the answer either way — the loop below picks it if it
+  // matches the requested traits, and the "at least return the first font"
+  // fallback picks the same one if it doesn't. Taking it here skips instantiating
+  // the face and querying its traits and weight, which is the whole cost of the
+  // scan. This is the common shape for a custom or expo-registered font.
+  if (names.count == 1) {
+    return names[0];
+  }
+
   BOOL isCondensed = NO;
-  UIFont *font = nil;
+  NSString *name = nil;
 
   // Get the closest font that matches the given weight for the fontFamily
   CGFloat closestWeight = INFINITY;
-  for (NSString *name in names) {
-    UIFont *match = [UIFont fontWithName:name size:fontSize];
+  for (NSString *candidate in names) {
+    UIFont *match = [UIFont fontWithName:candidate size:kFaceProbeFontSize];
+    // RN doesn't guard this, having no reason to expect a name the family itself
+    // just reported to be unloadable. Guarded here only because the trait calls
+    // below take a CTFontRef, where nil is a crash rather than a nil result.
+    if (match == nil) {
+      continue;
+    }
     if (isItalic == isItalicFont(match) && isCondensed == isCondensedFont(match)) {
       CGFloat testWeight = RCTGetFontWeight(match);
       if (ABS(testWeight - fontWeight) < ABS(closestWeight - fontWeight)) {
-        font = match;
+        name = candidate;
         closestWeight = testWeight;
       }
     }
@@ -100,11 +166,7 @@ closestFaceInFamily(NSArray<NSString *> *names, CGFloat fontSize, RCTFontWeight 
 
   // If we still don't have a match at least return the first font in the fontFamily
   // This is to support built-in font Zapfino and other custom single font families like Impact
-  if (!font && names.count > 0) {
-    font = [UIFont fontWithName:names[0] size:fontSize];
-  }
-
-  return font;
+  return name ?: names[0];
 }
 
 // Mirrors RCTFont.mm's RCTFontVariantDescriptor map: each fontVariant name
@@ -209,34 +271,42 @@ static NSDictionary<NSNumber *, NSNumber *> *fontVariations(const std::string &s
 
 static constexpr char kFieldSeparator = '|';
 
-// The five cache inputs joined into one key. Assembled as a std::string and
-// bridged once, so a hit costs a single NSString allocation instead of a trip
-// through the font database.
+// The three inputs that decide which face of a family to use: fontFamily,
+// fontWeight and italic. Also the leading fields of the full font key below, so
+// one string serves both and the shared part is built once.
 //
 // fontFamily and fontWeight are adjacent free-form strings, so a separator
 // inside either shifts the boundary between them — family "Foo|" at weight
 // "bold" keys the same as family "Foo" at weight "|bold". Left unguarded: it
 // takes a fontWeight no real style produces, and the worst case is one wrong
 // font, consistently, since both callers share the key.
-//
-// The variant names and the variation settings go last, where the same
-// ambiguity is unreachable: every name the mapping recognizes is
-// separator-free, and a separator inside the settings string makes it
-// unparseable, so any pair of keys that could be misread for one another
-// resolves to the same font, with no features and no axes.
-static NSString *fontCacheKey(
-    const std::string &fontFamily,
-    CGFloat fontSize,
-    const std::string &fontWeight,
-    bool italic,
-    const std::vector<std::string> &fontVariant,
-    const std::string &fontVariationSettings)
+static std::string faceCacheKey(const std::string &fontFamily, const std::string &fontWeight, bool italic)
 {
   std::string key = fontFamily;
   key += kFieldSeparator;
   key += fontWeight;
   key += kFieldSeparator;
   key += italic ? 'i' : 'n';
+  return key;
+}
+
+// The face key plus the three inputs that don't affect face selection: fontSize,
+// fontVariant and fontVariationSettings. Assembled as a std::string and bridged
+// once, so a hit costs a single NSString allocation instead of a trip through the
+// font database.
+//
+// The variant names and the variation settings go last, where the separator
+// ambiguity above is unreachable: every name the mapping recognizes is
+// separator-free, and a separator inside the settings string makes it
+// unparseable, so any pair of keys that could be misread for one another resolves
+// to the same font, with no features and no axes.
+static NSString *fontCacheKey(
+    const std::string &faceKey,
+    CGFloat fontSize,
+    const std::vector<std::string> &fontVariant,
+    const std::string &fontVariationSettings)
+{
+  std::string key = faceKey;
   key += kFieldSeparator;
   // Hundredths of a point, as an integer — sidestepping the padded
   // "17.000000" that std::to_string gives a double, and the cost of formatting
@@ -252,39 +322,87 @@ static NSString *fontCacheKey(
   return [NSString stringWithUTF8String:key.c_str()];
 }
 
+// One entry per distinct font key, and the key carries two continuous inputs —
+// fontSize, and any axis in fontVariationSettings — so the number of live entries
+// follows how many sizes and instances the app renders. Bounded so that an app
+// animating or otherwise sweeping either one can't grow it without limit; NSCache's
+// own eviction is driven by memory pressure, which arrives late and then drops
+// everything at once — the refill for that is what the face cache below makes
+// cheap. Well above any real type scale, times weights, styles and variants.
+static constexpr NSUInteger kFontCacheCountLimit = 256;
+
 static NSCache<NSString *, UIFont *> *fontCache()
 {
   static NSCache<NSString *, UIFont *> *cache;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     cache = [NSCache new];
-    // Two of the six key inputs are continuous — fontSize, and any axis in
-    // fontVariationSettings — so an animated weight or a size slider mints an
-    // entry per frame value. NSCache auto-evicts under memory pressure, which
-    // makes that growth rather than a leak, and each entry is a UIFont and a short
-    // string, so even hundreds of them are small. The limit is hygiene against the
-    // pathological case, not a fix for a measured problem.
-    //
-    // 128 rather than something tighter because eviction here is pure loss: a
-    // dropped entry costs a family resolution and a CTFont copy to rebuild, and
-    // NSCache's policy is documented as approximate and is not specified to be
-    // LRU, so what goes is not predictable. A design system's worth of text styles
-    // has to stay clear of the limit even with an animation running through it.
-    cache.countLimit = 128;
-    // Registering a font at runtime (expo-font, CTFontManagerRegisterFontsForURL)
-    // changes what a fontFamily resolves to, so every entry cached before it
-    // landed is suspect — in particular the system fallback returned while the
-    // family was still unknown, which would otherwise outlive the registration.
-    // RCTFont.mm's family-name cache clears on the same notification.
-    [NSNotificationCenter.defaultCenter
-        addObserverForName:(NSNotificationName)kCTFontManagerRegisteredFontsChangedNotification
-                    object:nil
-                     queue:nil
-                usingBlock:^(NSNotification *) {
-                  [cache removeAllObjects];
-                }];
+    cache.countLimit = kFontCacheCountLimit;
+    clearOnFontRegistration(cache);
   });
   return cache;
+}
+
+// Stored in place of a face name for a fontFamily that names neither a known
+// family nor a known face. NSCache can't hold nil, and re-deriving "still
+// unresolvable" means re-enumerating the font database and re-logging, once per
+// size, for as long as the typo is on screen.
+static NSString *const kUnresolvableFace = @"";
+
+/*
+ * The face name to instantiate for this fontFamily, or nil if it resolves to
+ * nothing and the caller should fall back to the system font.
+ *
+ * Cached separately from the font itself because the answer doesn't depend on
+ * fontSize (see kFaceProbeFontSize): without this, every new size re-ran the
+ * family scan — N font instantiations, 2N symbolic-trait queries and N
+ * RCTGetFontWeight calls — to arrive at the name it already knew.
+ */
+static NSString *resolvedFaceName(
+    const std::string &fontFamily,
+    const std::string &faceKey,
+    RCTFontWeight fontWeight,
+    BOOL isItalic)
+{
+  static NSCache<NSString *, NSString *> *cache;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    cache = [NSCache new];
+    clearOnFontRegistration(cache);
+  });
+
+  NSString *key = [NSString stringWithUTF8String:faceKey.c_str()];
+  NSString *cached = key != nil ? [cache objectForKey:key] : nil;
+  if (cached != nil) {
+    return cached.length > 0 ? cached : nil;
+  }
+
+  NSString *familyName = [NSString stringWithUTF8String:fontFamily.c_str()];
+  NSString *faceName = nil;
+  if (familyName != nil) {
+    faceName = closestFaceNameInFamily(cachedFontNamesForFamilyName(familyName), fontWeight, isItalic);
+    if (faceName == nil) {
+      // Not a registered family, so take it for the face / PostScript name it
+      // probably is ("OpenRunde-Bold" rather than "Open Runde"). An expo-font
+      // alias lands in the branch above instead: the swizzled
+      // +fontNamesForFamilyName: answers it with a one-element array.
+      if ([UIFont fontWithName:familyName size:kFaceProbeFontSize] != nil) {
+        faceName = familyName;
+      } else {
+        // Same message and same level as RCTFont.mm, from the same branch, so a
+        // typo reads identically whether it hit <PlainText> or <Text>. Info
+        // rather than warn keeps it out of LogBox, which is RN's call, not ours
+        // — the substitution is cosmetic, and this now fires once per distinct
+        // family/weight/style rather than once per size on top of that.
+        RCTLogInfo(@"Unrecognized font family '%@'", familyName);
+      }
+    }
+  }
+
+  if (key != nil) {
+    [cache setObject:(faceName ?: kUnresolvableFace) forKey:key];
+  }
+  return faceName;
 }
 
 CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseMultiplier)
@@ -298,16 +416,19 @@ CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseM
   return baseMultiplier;
 }
 
+CGFloat plainTextScaledFontSize(CGFloat fontSize, CGFloat fontSizeMultiplier)
+{
+  if (fontSizeMultiplier <= 0.0 || fontSizeMultiplier == 1.0) {
+    return fontSize;
+  }
+  return std::round(fontSize * fontSizeMultiplier);
+}
+
 UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSize)
 {
   bool italic = props.fontStyle == RNPlainTextFontStyle::Italic;
-  NSString *key = fontCacheKey(
-      props.fontFamily,
-      fontSize,
-      props.fontWeight,
-      italic,
-      props.fontVariant,
-      props.fontVariationSettings);
+  std::string faceKey = faceCacheKey(props.fontFamily, props.fontWeight, italic);
+  NSString *key = fontCacheKey(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);
 
   NSCache<NSString *, UIFont *> *cache = fontCache();
   UIFont *font = [cache objectForKey:key];
@@ -317,24 +438,9 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSize)
 
   UIFontWeight weight = fontWeightFromProp(props.fontWeight);
   if (!props.fontFamily.empty()) {
-    NSString *fontFamily = [NSString stringWithUTF8String:props.fontFamily.c_str()];
-    NSArray<NSString *> *fontNames = [UIFont fontNamesForFamilyName:fontFamily];
-    if (fontNames.count > 0) {
-      font = closestFaceInFamily(fontNames, fontSize, weight, italic);
-    } else {
-      // Not a registered family, so take it for the face / PostScript name it
-      // probably is ("OpenRunde-Bold" rather than "Open Runde"). An expo-font
-      // alias lands in the branch above instead: the swizzled
-      // +fontNamesForFamilyName: answers it with a one-element array.
-      font = [UIFont fontWithName:fontFamily size:fontSize];
-      if (font == nil) {
-        // Same message and same level as RCTFont.mm, from the same branch, so a
-        // typo reads identically whether it hit <PlainText> or <Text>. Info
-        // rather than warn keeps it out of LogBox, which is RN's call, not ours
-        // — the substitution is cosmetic, and this fires once per cache miss
-        // (so once per distinct fontSize, not once per commit).
-        RCTLogInfo(@"Unrecognized font family '%@'", fontFamily);
-      }
+    NSString *faceName = resolvedFaceName(props.fontFamily, faceKey, weight, italic);
+    if (faceName != nil) {
+      font = [UIFont fontWithName:faceName size:fontSize];
     }
   }
 
@@ -347,7 +453,7 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSize)
     font = [UIFont systemFontOfSize:fontSize weight:weight];
   }
 
-  // Only when the resolved face isn't already italic — closestFaceInFamily
+  // Only when the resolved face isn't already italic — closestFaceNameInFamily
   // prefers the family's real italic cut, which beats a synthesized slant.
   if (italic && !isItalicFont(font)) {
     UIFontDescriptor *italicDescriptor = [font.fontDescriptor

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -202,6 +202,7 @@ static NSString *computeFaceName(
     const std::string &fontFamily,
     const std::string &fontWeightProp,
     RCTFontWeight fontWeight,
+    const std::string &fontStyleProp,
     BOOL isItalic)
 {
   NSString *familyName = [NSString stringWithUTF8String:fontFamily.c_str()];
@@ -235,16 +236,15 @@ static NSString *computeFaceName(
   //
   // A prop that wasn't set inherits the matched face's own trait rather than
   // a hardcoded default, exactly as RCTFont.mm's `style ? isItalic :
-  // isItalicFont(font)` / `weight ? fontWeight : RCTGetFontWeight(font)` do —
-  // isItalic has no "unset" of its own to check (fontStyle's codegen default
-  // collapses "not passed" and "normal" into the same enum value, see
-  // PlainTextViewNativeComponent.ts), so a caller-true isItalic wins and a
-  // caller-false one falls through to the face.
+  // isItalicFont(font)` / `weight ? fontWeight : RCTGetFontWeight(font)` do.
+  // Both branch on whether the *raw* prop was passed, not on the converted
+  // value, so fontStyleProp/fontWeightProp (empty means "not passed") decide
+  // the fallback rather than isItalic/fontWeight themselves.
   NSString *realFamilyName = namedFont.familyName;
   BOOL faceIsItalic = isItalicFont(namedFont);
   BOOL faceIsCondensed = isCondensedFont(namedFont);
   RCTFontWeight faceWeight = RCTGetFontWeight(namedFont);
-  BOOL effectiveIsItalic = isItalic || faceIsItalic;
+  BOOL effectiveIsItalic = fontStyleProp.empty() ? faceIsItalic : isItalic;
   RCTFontWeight effectiveWeight = fontWeightProp.empty() ? faceWeight : fontWeight;
   return closestFaceNameInFamily(
              cachedFontNamesForFamilyName(realFamilyName), effectiveWeight, effectiveIsItalic, faceIsCondensed)
@@ -259,6 +259,7 @@ static NSString *resolvedFaceName(
     const std::string &faceKey,
     const std::string &fontWeightProp,
     RCTFontWeight fontWeight,
+    const std::string &fontStyleProp,
     BOOL isItalic)
 {
   static PlainTextFontCache<NSString *, NSString *> *faceNamesCache =
@@ -266,11 +267,11 @@ static NSString *resolvedFaceName(
 
   NSString *key = [NSString stringWithUTF8String:faceKey.c_str()];
   if (key == nil) {
-    return computeFaceName(fontFamily, fontWeightProp, fontWeight, isItalic);
+    return computeFaceName(fontFamily, fontWeightProp, fontWeight, fontStyleProp, isItalic);
   }
   return [faceNamesCache objectForKey:key
                                  orSet:^NSString * {
-                                   return computeFaceName(fontFamily, fontWeightProp, fontWeight, isItalic);
+                                   return computeFaceName(fontFamily, fontWeightProp, fontWeight, fontStyleProp, isItalic);
                                  }];
 }
 
@@ -292,7 +293,7 @@ static UIFont *resolvedFont(const RNPlainTextProps &props, const std::string &fa
   // sent through the family lookup below, where no family is actually
   // registered as "System" and it would only fail and log.
   if (!props.fontFamily.empty() && props.fontFamily != "System") {
-    NSString *faceName = resolvedFaceName(props.fontFamily, faceKey, props.fontWeight, weight, italic);
+    NSString *faceName = resolvedFaceName(props.fontFamily, faceKey, props.fontWeight, weight, props.fontStyle, italic);
     if (faceName != nil) {
       font = [UIFont fontWithName:faceName size:fontSize];
     }
@@ -360,8 +361,8 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
       [[PlainTextFontCache alloc] initWithCountLimit:kFontCacheCountLimit];
 
   CGFloat fontSize = scaledFontSize(props.fontSize, fontSizeMultiplier);
-  bool italic = props.fontStyle == RNPlainTextFontStyle::Italic;
-  std::string faceKey = faceCacheKey(props.fontFamily, props.fontWeight, italic);
+  bool italic = isItalicFromProp(props.fontStyle);
+  std::string faceKey = faceCacheKey(props.fontFamily, props.fontWeight, props.fontStyle);
   std::string cacheKey = fontCacheKey(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);
   NSString *key = [NSString stringWithUTF8String:cacheKey.c_str()];
 

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -202,14 +202,14 @@ static NSString *computeFaceName(
     const std::string &fontFamily,
     const std::string &fontWeightProp,
     RCTFontWeight fontWeight,
-    const std::string &fontStyleProp,
-    BOOL isItalic)
+    const std::string &fontStyleProp)
 {
   NSString *familyName = [NSString stringWithUTF8String:fontFamily.c_str()];
   if (familyName == nil) {
     return nil;
   }
 
+  BOOL isItalic = isItalicFromProp(fontStyleProp);
   NSString *faceName = closestFaceNameInFamily(cachedFontNamesForFamilyName(familyName), fontWeight, isItalic, NO);
   if (faceName != nil) {
     return faceName;
@@ -259,19 +259,18 @@ static NSString *resolvedFaceName(
     const std::string &faceKey,
     const std::string &fontWeightProp,
     RCTFontWeight fontWeight,
-    const std::string &fontStyleProp,
-    BOOL isItalic)
+    const std::string &fontStyleProp)
 {
   static PlainTextFontCache<NSString *, NSString *> *faceNamesCache =
       [[PlainTextFontCache alloc] initWithCountLimit:0];
 
   NSString *key = [NSString stringWithUTF8String:faceKey.c_str()];
   if (key == nil) {
-    return computeFaceName(fontFamily, fontWeightProp, fontWeight, fontStyleProp, isItalic);
+    return computeFaceName(fontFamily, fontWeightProp, fontWeight, fontStyleProp);
   }
   return [faceNamesCache objectForKey:key
                                  orSet:^NSString * {
-                                   return computeFaceName(fontFamily, fontWeightProp, fontWeight, fontStyleProp, isItalic);
+                                   return computeFaceName(fontFamily, fontWeightProp, fontWeight, fontStyleProp);
                                  }];
 }
 
@@ -293,7 +292,7 @@ static UIFont *resolvedFont(const RNPlainTextProps &props, const std::string &fa
   // sent through the family lookup below, where no family is actually
   // registered as "System" and it would only fail and log.
   if (!props.fontFamily.empty() && props.fontFamily != "System") {
-    NSString *faceName = resolvedFaceName(props.fontFamily, faceKey, props.fontWeight, weight, props.fontStyle, italic);
+    NSString *faceName = resolvedFaceName(props.fontFamily, faceKey, props.fontWeight, weight, props.fontStyle);
     if (faceName != nil) {
       font = [UIFont fontWithName:faceName size:fontSize];
     }

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -184,13 +184,6 @@ static NSDictionary<NSNumber *, NSNumber *> *fontVariations(const std::string &s
 // weights, styles and variants.
 static constexpr NSUInteger kFontCacheCountLimit = 256;
 
-static PlainTextFontCache<NSString *, UIFont *> *fontCache()
-{
-  static PlainTextFontCache<NSString *, UIFont *> *resolvedFontsCache =
-      [[PlainTextFontCache alloc] initWithCountLimit:kFontCacheCountLimit];
-  return resolvedFontsCache;
-}
-
 /*
  * The face name to instantiate for this fontFamily, or nil if it resolves to
  * nothing and the caller should fall back to the system font.
@@ -359,16 +352,19 @@ static UIFont *resolvedFont(const RNPlainTextProps &props, const std::string &fa
 
 UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
 {
+  static PlainTextFontCache<NSString *, UIFont *> *resolvedFontsCache =
+      [[PlainTextFontCache alloc] initWithCountLimit:kFontCacheCountLimit];
+
   CGFloat fontSize = scaledFontSize(props.fontSize, fontSizeMultiplier);
   bool italic = props.fontStyle == RNPlainTextFontStyle::Italic;
   std::string faceKey = faceCacheKey(props.fontFamily, props.fontWeight, italic);
   std::string cacheKey = fontCacheKey(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);
   NSString *key = [NSString stringWithUTF8String:cacheKey.c_str()];
 
-  return [fontCache() objectForKey:key
-                              orSet:^UIFont * {
-                                return resolvedFont(props, faceKey, fontSize, italic);
-                              }];
+  return [resolvedFontsCache objectForKey:key
+                                     orSet:^UIFont * {
+                                       return resolvedFont(props, faceKey, fontSize, italic);
+                                     }];
 }
 
 } // namespace facebook::react

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -10,7 +10,6 @@
 #import <React/RCTFont.h>
 #import <React/RCTLog.h>
 
-#import <cmath>
 #import <optional>
 #import <string>
 #import <vector>
@@ -176,20 +175,6 @@ static NSDictionary<NSNumber *, NSNumber *> *fontVariations(const std::string &s
     variations[@(axis.tag)] = @(axis.value);
   }
   return variations;
-}
-
-// Bridges fontCacheKey's std::string result to NSString, so a hit costs a
-// single NSString allocation instead of a trip through the font database.
-// The key-building logic itself lives in PlainTextFontCacheKey.cpp, where it
-// can be tested without an ObjC round-trip.
-static NSString *fontCacheKeyString(
-    const std::string &faceKey,
-    CGFloat fontSize,
-    const std::vector<std::string> &fontVariant,
-    const std::string &fontVariationSettings)
-{
-  std::string key = fontCacheKey(faceKey, fontSize, fontVariant, fontVariationSettings);
-  return [NSString stringWithUTF8String:key.c_str()];
 }
 
 // The key carries two continuous inputs — fontSize, and any axis in
@@ -377,7 +362,8 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
   CGFloat fontSize = scaledFontSize(props.fontSize, fontSizeMultiplier);
   bool italic = props.fontStyle == RNPlainTextFontStyle::Italic;
   std::string faceKey = faceCacheKey(props.fontFamily, props.fontWeight, italic);
-  NSString *key = fontCacheKeyString(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);
+  std::string cacheKey = fontCacheKey(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);
+  NSString *key = [NSString stringWithUTF8String:cacheKey.c_str()];
 
   return [fontCache() objectForKey:key
                               orSet:^UIFont * {

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -1,6 +1,8 @@
 #import "PlainTextFont.h"
 
+#import "PlainTextFontCache.h"
 #import "PlainTextFontCacheKey.h"
+#import "PlainTextFontLookupTables.h"
 #import "PlainTextFontSizing.h"
 #import "PlainTextFontVariations.h"
 
@@ -15,63 +17,22 @@
 
 namespace facebook::react {
 
-// Mirrors RCTFont.mm's core weight map (RCTConvert RCTFontWeight): the named
-// aliases beyond "normal"/"bold" (e.g. "ultralight", "condensed") are dropped
-// since codegen can't type fontWeight as an enum (see PlainTextViewNativeComponent.ts).
-static UIFontWeight fontWeightFromProp(const std::string &fontWeight)
-{
-  static NSDictionary<NSString *, NSNumber *> *weights = @{
-    @"normal" : @(UIFontWeightRegular),
-    @"bold" : @(UIFontWeightBold),
-    @"100" : @(UIFontWeightUltraLight),
-    @"200" : @(UIFontWeightThin),
-    @"300" : @(UIFontWeightLight),
-    @"400" : @(UIFontWeightRegular),
-    @"500" : @(UIFontWeightMedium),
-    @"600" : @(UIFontWeightSemibold),
-    @"700" : @(UIFontWeightBold),
-    @"800" : @(UIFontWeightHeavy),
-    @"900" : @(UIFontWeightBlack),
-  };
-  NSString *key = [NSString stringWithUTF8String:fontWeight.c_str()];
-  NSNumber *weight = weights[key];
-  return weight != nil ? (UIFontWeight)weight.doubleValue : UIFontWeightRegular;
-}
-
-// Registering a font at runtime (expo-font, CTFontManagerRegisterFontsForURL)
-// changes what a fontFamily resolves to, so every cache here is stale after it —
-// in particular an entry that resolved while the family was still unknown.
-// RCTFont.mm clears its own family-name cache on the same notification.
-static void clearOnFontRegistration(NSCache *cache)
-{
-  [NSNotificationCenter.defaultCenter
-      addObserverForName:(NSNotificationName)kCTFontManagerRegisteredFontsChangedNotification
-                  object:nil
-                   queue:nil
-              usingBlock:^(NSNotification *) {
-                [cache removeAllObjects];
-              }];
-}
-
 // Caching wrapper around +[UIFont fontNamesForFamilyName:], which enumerates the
 // font database — RCTFont.mm calls it expensive and wraps it the same way. The
 // empty answer is cached too: a fontFamily naming a face rather than a family
 // ("OpenRunde-Bold") never produces a list, and would ask on every lookup.
 static NSArray<NSString *> *cachedFontNamesForFamilyName(NSString *familyName)
 {
-  static NSCache<NSString *, NSArray<NSString *> *> *cache;
+  static PlainTextFontCache<NSString *, NSArray<NSString *> *> *familyNamesCache;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    cache = [NSCache new];
-    clearOnFontRegistration(cache);
+    familyNamesCache = [[PlainTextFontCache alloc] initWithCountLimit:0];
   });
 
-  NSArray<NSString *> *names = [cache objectForKey:familyName];
-  if (names == nil) {
-    names = [UIFont fontNamesForFamilyName:familyName] ?: @[];
-    [cache setObject:names forKey:familyName];
-  }
-  return names;
+  return [familyNamesCache objectForKey:familyName
+                                   orSet:^NSArray<NSString *> * {
+                                     return [UIFont fontNamesForFamilyName:familyName] ?: @[];
+                                   }];
 }
 
 /*
@@ -170,56 +131,6 @@ static NSString *closestFaceNameInFamily(
   return name ?: names[0];
 }
 
-// Mirrors RCTFont.mm's RCTFontVariantDescriptor map: each fontVariant name
-// names one OpenType feature, expressed as the type/selector identifier pair
-// UIFontDescriptor takes. Unrecognized names are dropped, as RN drops them.
-static NSDictionary<NSString *, NSDictionary *> *fontVariantDescriptors()
-{
-  static NSDictionary<NSString *, NSDictionary *> *descriptors;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-#define RNPlainTextFeature(type, selector) \
-  @{UIFontFeatureTypeIdentifierKey : @(type), UIFontFeatureSelectorIdentifierKey : @(selector)}
-    descriptors = @{
-      @"small-caps" : RNPlainTextFeature(kLowerCaseType, kLowerCaseSmallCapsSelector),
-      @"oldstyle-nums" : RNPlainTextFeature(kNumberCaseType, kLowerCaseNumbersSelector),
-      @"lining-nums" : RNPlainTextFeature(kNumberCaseType, kUpperCaseNumbersSelector),
-      @"tabular-nums" : RNPlainTextFeature(kNumberSpacingType, kMonospacedNumbersSelector),
-      @"proportional-nums" : RNPlainTextFeature(kNumberSpacingType, kProportionalNumbersSelector),
-      @"common-ligatures" : RNPlainTextFeature(kLigaturesType, kCommonLigaturesOnSelector),
-      @"no-common-ligatures" : RNPlainTextFeature(kLigaturesType, kCommonLigaturesOffSelector),
-      @"discretionary-ligatures" : RNPlainTextFeature(kLigaturesType, kRareLigaturesOnSelector),
-      @"no-discretionary-ligatures" : RNPlainTextFeature(kLigaturesType, kRareLigaturesOffSelector),
-      @"historical-ligatures" : RNPlainTextFeature(kLigaturesType, kHistoricalLigaturesOnSelector),
-      @"no-historical-ligatures" : RNPlainTextFeature(kLigaturesType, kHistoricalLigaturesOffSelector),
-      @"contextual" : RNPlainTextFeature(kContextualAlternatesType, kContextualAlternatesOnSelector),
-      @"no-contextual" : RNPlainTextFeature(kContextualAlternatesType, kContextualAlternatesOffSelector),
-      @"stylistic-one" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltOneOnSelector),
-      @"stylistic-two" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltTwoOnSelector),
-      @"stylistic-three" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltThreeOnSelector),
-      @"stylistic-four" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltFourOnSelector),
-      @"stylistic-five" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltFiveOnSelector),
-      @"stylistic-six" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltSixOnSelector),
-      @"stylistic-seven" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltSevenOnSelector),
-      @"stylistic-eight" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltEightOnSelector),
-      @"stylistic-nine" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltNineOnSelector),
-      @"stylistic-ten" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltTenOnSelector),
-      @"stylistic-eleven" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltElevenOnSelector),
-      @"stylistic-twelve" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltTwelveOnSelector),
-      @"stylistic-thirteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltThirteenOnSelector),
-      @"stylistic-fourteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltFourteenOnSelector),
-      @"stylistic-fifteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltFifteenOnSelector),
-      @"stylistic-sixteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltSixteenOnSelector),
-      @"stylistic-seventeen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltSeventeenOnSelector),
-      @"stylistic-eighteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltEighteenOnSelector),
-      @"stylistic-nineteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltNineteenOnSelector),
-      @"stylistic-twenty" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltTwentyOnSelector),
-    };
-#undef RNPlainTextFeature
-  });
-  return descriptors;
-}
-
 // The feature settings for these variant names, or nil when none of them
 // resolve — the caller skips the descriptor round-trip in that case.
 static NSArray<NSDictionary *> *fontFeatureSettings(const std::vector<std::string> &fontVariant)
@@ -291,30 +202,19 @@ static NSString *fontCacheKeyString(
 // weights, styles and variants.
 static constexpr NSUInteger kFontCacheCountLimit = 256;
 
-static NSCache<NSString *, UIFont *> *fontCache()
+static PlainTextFontCache<NSString *, UIFont *> *fontCache()
 {
-  static NSCache<NSString *, UIFont *> *cache;
+  static PlainTextFontCache<NSString *, UIFont *> *resolvedFontsCache;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    cache = [NSCache new];
-    cache.countLimit = kFontCacheCountLimit;
-    clearOnFontRegistration(cache);
+    resolvedFontsCache = [[PlainTextFontCache alloc] initWithCountLimit:kFontCacheCountLimit];
   });
-  return cache;
+  return resolvedFontsCache;
 }
-
-// Cached in place of a face name for a fontFamily that names neither a known
-// family nor a known face, since NSCache can't hold nil and re-deriving "still
-// unresolvable" costs a walk of the font database and another log line.
-static NSString *const kUnresolvableFace = @"";
 
 /*
  * The face name to instantiate for this fontFamily, or nil if it resolves to
  * nothing and the caller should fall back to the system font.
- *
- * Cached apart from the font itself because the answer doesn't depend on fontSize
- * (see kFaceProbeFontSize), so a new size costs one font instantiation instead of
- * another scan of the family.
  *
  * `fontWeightProp` is the raw prop string, not just the weight it maps to: an
  * empty string is RN's own signal that fontWeight wasn't set (RCTFont.mm reads
@@ -322,6 +222,62 @@ static NSString *const kUnresolvableFace = @"";
  * that signal to know whether to keep the caller's weight or take the matched
  * face's own.
  */
+static NSString *computeFaceName(
+    const std::string &fontFamily,
+    const std::string &fontWeightProp,
+    RCTFontWeight fontWeight,
+    BOOL isItalic)
+{
+  NSString *familyName = [NSString stringWithUTF8String:fontFamily.c_str()];
+  if (familyName == nil) {
+    return nil;
+  }
+
+  NSString *faceName = closestFaceNameInFamily(cachedFontNamesForFamilyName(familyName), fontWeight, isItalic, NO);
+  if (faceName != nil) {
+    return faceName;
+  }
+
+  // Not a registered family, so take it for the face / PostScript name it
+  // probably is ("OpenRunde-Bold" rather than "Open Runde"). An expo-font
+  // alias lands in the branch above instead: the swizzled
+  // +fontNamesForFamilyName: answers it with a one-element array.
+  UIFont *namedFont = [UIFont fontWithName:familyName size:kFaceProbeFontSize];
+  if (namedFont == nil) {
+    // Same message and same level as RCTFont.mm, from the same branch, so a
+    // typo reads identically whether it hit <PlainText> or <Text>. Info
+    // rather than warn keeps it out of LogBox, which is RN's call, not ours.
+    RCTLogInfo(@"Unrecognized font family '%@'", familyName);
+    return nil;
+  }
+
+  // RN doesn't stop here either ("we'll do what was meant, not what was
+  // said"): it re-derives the real family from this face and searches that
+  // family for the closest match to what the props actually ask for, so
+  // "Georgia-Bold" + fontStyle: "italic" lands on the family's real
+  // BoldItalic face instead of a synthesized slant on Georgia-Bold.
+  //
+  // A prop that wasn't set inherits the matched face's own trait rather than
+  // a hardcoded default, exactly as RCTFont.mm's `style ? isItalic :
+  // isItalicFont(font)` / `weight ? fontWeight : RCTGetFontWeight(font)` do —
+  // isItalic has no "unset" of its own to check (fontStyle's codegen default
+  // collapses "not passed" and "normal" into the same enum value, see
+  // PlainTextViewNativeComponent.ts), so a caller-true isItalic wins and a
+  // caller-false one falls through to the face.
+  NSString *realFamilyName = namedFont.familyName;
+  BOOL faceIsItalic = isItalicFont(namedFont);
+  BOOL faceIsCondensed = isCondensedFont(namedFont);
+  RCTFontWeight faceWeight = RCTGetFontWeight(namedFont);
+  BOOL effectiveIsItalic = isItalic || faceIsItalic;
+  RCTFontWeight effectiveWeight = fontWeightProp.empty() ? faceWeight : fontWeight;
+  return closestFaceNameInFamily(
+             cachedFontNamesForFamilyName(realFamilyName), effectiveWeight, effectiveIsItalic, faceIsCondensed)
+      ?: familyName;
+}
+
+// Cached apart from the font itself because the answer doesn't depend on
+// fontSize (see kFaceProbeFontSize), so a new size costs one font
+// instantiation instead of another scan of the family.
 static NSString *resolvedFaceName(
     const std::string &fontFamily,
     const std::string &faceKey,
@@ -329,65 +285,20 @@ static NSString *resolvedFaceName(
     RCTFontWeight fontWeight,
     BOOL isItalic)
 {
-  static NSCache<NSString *, NSString *> *cache;
+  static PlainTextFontCache<NSString *, NSString *> *faceNamesCache;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    cache = [NSCache new];
-    clearOnFontRegistration(cache);
+    faceNamesCache = [[PlainTextFontCache alloc] initWithCountLimit:0];
   });
 
   NSString *key = [NSString stringWithUTF8String:faceKey.c_str()];
-  NSString *cached = key != nil ? [cache objectForKey:key] : nil;
-  if (cached != nil) {
-    return cached.length > 0 ? cached : nil;
+  if (key == nil) {
+    return computeFaceName(fontFamily, fontWeightProp, fontWeight, isItalic);
   }
-
-  NSString *familyName = [NSString stringWithUTF8String:fontFamily.c_str()];
-  NSString *faceName = nil;
-  if (familyName != nil) {
-    faceName = closestFaceNameInFamily(cachedFontNamesForFamilyName(familyName), fontWeight, isItalic, NO);
-    if (faceName == nil) {
-      // Not a registered family, so take it for the face / PostScript name it
-      // probably is ("OpenRunde-Bold" rather than "Open Runde"). An expo-font
-      // alias lands in the branch above instead: the swizzled
-      // +fontNamesForFamilyName: answers it with a one-element array.
-      UIFont *namedFont = [UIFont fontWithName:familyName size:kFaceProbeFontSize];
-      if (namedFont != nil) {
-        // RN doesn't stop here either ("we'll do what was meant, not what was
-        // said"): it re-derives the real family from this face and searches
-        // that family for the closest match to what the props actually ask
-        // for, so "Georgia-Bold" + fontStyle: "italic" lands on the family's
-        // real BoldItalic face instead of a synthesized slant on Georgia-Bold.
-        //
-        // A prop that wasn't set inherits the matched face's own trait rather
-        // than a hardcoded default, exactly as RCTFont.mm's `style ? isItalic
-        // : isItalicFont(font)` / `weight ? fontWeight : RCTGetFontWeight(font)`
-        // do — isItalic has no "unset" of its own to check (fontStyle's
-        // codegen default collapses "not passed" and "normal" into the same
-        // enum value, see PlainTextViewNativeComponent.ts), so a caller-true
-        // isItalic wins and a caller-false one falls through to the face.
-        NSString *realFamilyName = namedFont.familyName;
-        BOOL faceIsItalic = isItalicFont(namedFont);
-        BOOL faceIsCondensed = isCondensedFont(namedFont);
-        RCTFontWeight faceWeight = RCTGetFontWeight(namedFont);
-        BOOL effectiveIsItalic = isItalic || faceIsItalic;
-        RCTFontWeight effectiveWeight = fontWeightProp.empty() ? faceWeight : fontWeight;
-        faceName = closestFaceNameInFamily(
-                       cachedFontNamesForFamilyName(realFamilyName), effectiveWeight, effectiveIsItalic, faceIsCondensed)
-            ?: familyName;
-      } else {
-        // Same message and same level as RCTFont.mm, from the same branch, so a
-        // typo reads identically whether it hit <PlainText> or <Text>. Info
-        // rather than warn keeps it out of LogBox, which is RN's call, not ours.
-        RCTLogInfo(@"Unrecognized font family '%@'", familyName);
-      }
-    }
-  }
-
-  if (key != nil) {
-    [cache setObject:(faceName ?: kUnresolvableFace) forKey:key];
-  }
-  return faceName;
+  return [faceNamesCache objectForKey:key
+                                 orSet:^NSString * {
+                          return computeFaceName(fontFamily, fontWeightProp, fontWeight, isItalic);
+                        }];
 }
 
 CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseMultiplier)
@@ -395,20 +306,14 @@ CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseM
   return clampFontSizeMultiplier(props.allowFontScaling, props.maxFontSizeMultiplier, baseMultiplier);
 }
 
-UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
+// The UIFont for these props at this already-scaled fontSize and faceKey —
+// the resolution plainTextFont's cache wraps. Never nil: an unresolvable
+// fontFamily falls back to the system font, since both of plainTextFont's
+// callers would otherwise silently measure and draw with different defaults.
+static UIFont *resolvedFont(const RNPlainTextProps &props, const std::string &faceKey, CGFloat fontSize, bool italic)
 {
-  CGFloat fontSize = scaledFontSize(props.fontSize, fontSizeMultiplier);
-  bool italic = props.fontStyle == RNPlainTextFontStyle::Italic;
-  std::string faceKey = faceCacheKey(props.fontFamily, props.fontWeight, italic);
-  NSString *key = fontCacheKeyString(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);
-
-  NSCache<NSString *, UIFont *> *cache = fontCache();
-  UIFont *font = [cache objectForKey:key];
-  if (font != nil) {
-    return font;
-  }
-
   UIFontWeight weight = fontWeightFromProp(props.fontWeight);
+  UIFont *font = nil;
   // "System" is RCTFont.mm's own special case for the system font by name
   // (RN's <Text> accepts it the same way), so it's excluded here rather than
   // sent through the family lookup below, where no family is actually
@@ -422,9 +327,8 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
 
   // No fontFamily (or "System"), or one naming neither a known family nor a
   // known face — the latter is RCTFont.mm's fallback too. Everything
-  // downstream needs a real font: the italic round-trip below, and both
-  // callers, which read font.lineHeight to cap numberOfLines and would
-  // otherwise measure and draw with different defaults.
+  // downstream needs a real font: the italic round-trip below, and both of
+  // plainTextFont's callers, which read font.lineHeight to cap numberOfLines.
   if (font == nil) {
     font = [UIFont systemFontOfSize:fontSize weight:weight];
   }
@@ -474,11 +378,20 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
     }
   }
 
-  // Every round-trip above keeps the font it started from if the descriptor
-  // fails to resolve, so `font` is non-nil from the fallback onwards — no guard
-  // needed here, and NSCache would raise on a nil object.
-  [cache setObject:font forKey:key];
   return font;
+}
+
+UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
+{
+  CGFloat fontSize = scaledFontSize(props.fontSize, fontSizeMultiplier);
+  bool italic = props.fontStyle == RNPlainTextFontStyle::Italic;
+  std::string faceKey = faceCacheKey(props.fontFamily, props.fontWeight, italic);
+  NSString *key = fontCacheKeyString(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);
+
+  return [fontCache() objectForKey:key
+                              orSet:^UIFont * {
+                                return resolvedFont(props, faceKey, fontSize, italic);
+                              }];
 }
 
 } // namespace facebook::react

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -1,5 +1,7 @@
 #import "PlainTextFont.h"
 
+#import "PlainTextFontCacheKey.h"
+#import "PlainTextFontSizing.h"
 #import "PlainTextFontVariations.h"
 
 #import <CoreText/CoreText.h>
@@ -268,56 +270,17 @@ static NSDictionary<NSNumber *, NSNumber *> *fontVariations(const std::string &s
   return variations;
 }
 
-static constexpr char kFieldSeparator = '|';
-
-// The three inputs that decide which face of a family to use: fontFamily,
-// fontWeight and italic. Also the leading fields of the full font key below, so
-// one string serves both and the shared part is built once.
-//
-// fontFamily and fontWeight are adjacent free-form strings, so a separator
-// inside either shifts the boundary between them — family "Foo|" at weight
-// "bold" keys the same as family "Foo" at weight "|bold". Left unguarded: it
-// takes a fontWeight no real style produces, and the worst case is one wrong
-// font, consistently, since both callers share the key.
-static std::string faceCacheKey(const std::string &fontFamily, const std::string &fontWeight, bool italic)
-{
-  std::string key = fontFamily;
-  key += kFieldSeparator;
-  key += fontWeight;
-  key += kFieldSeparator;
-  key += italic ? 'i' : 'n';
-  return key;
-}
-
-// The face key plus the three inputs that don't affect face selection: fontSize,
-// fontVariant and fontVariationSettings. Assembled as a std::string and bridged
-// once, so a hit costs a single NSString allocation instead of a trip through the
-// font database.
-//
-// The variant names and the variation settings go last, where the separator
-// ambiguity above is unreachable: every name the mapping recognizes is
-// separator-free, and a separator inside the settings string makes it
-// unparseable, so any pair of keys that could be misread for one another resolves
-// to the same font, with no features and no axes.
-static NSString *fontCacheKey(
+// Bridges fontCacheKey's std::string result to NSString, so a hit costs a
+// single NSString allocation instead of a trip through the font database.
+// The key-building logic itself lives in PlainTextFontCacheKey.cpp, where it
+// can be tested without an ObjC round-trip.
+static NSString *fontCacheKeyString(
     const std::string &faceKey,
     CGFloat fontSize,
     const std::vector<std::string> &fontVariant,
     const std::string &fontVariationSettings)
 {
-  std::string key = faceKey;
-  key += kFieldSeparator;
-  // Hundredths of a point, as an integer — sidestepping the padded
-  // "17.000000" that std::to_string gives a double, and the cost of formatting
-  // one. Sizes closer together than that render identically at any screen
-  // scale, so collapsing them onto one entry is correct rather than lossy.
-  key += std::to_string(std::lround(fontSize * 100));
-  for (const std::string &variant : fontVariant) {
-    key += kFieldSeparator;
-    key += variant;
-  }
-  key += kFieldSeparator;
-  key += fontVariationSettings;
+  std::string key = fontCacheKey(faceKey, fontSize, fontVariant, fontVariationSettings);
   return [NSString stringWithUTF8String:key.c_str()];
 }
 
@@ -429,24 +392,7 @@ static NSString *resolvedFaceName(
 
 CGFloat plainTextFontSizeMultiplier(const RNPlainTextProps &props, CGFloat baseMultiplier)
 {
-  if (!props.allowFontScaling) {
-    return 1.0;
-  }
-  if (props.maxFontSizeMultiplier >= 1.0) {
-    return fminf((CGFloat)props.maxFontSizeMultiplier, baseMultiplier);
-  }
-  return baseMultiplier;
-}
-
-// Rounded to whole points when a multiplier applies and left alone when none
-// does, both as in RCTFont.mm — so a Dynamic Type setting lands on the same size
-// RN's <Text> uses, and a fractional fontSize prop keeps its fraction.
-static CGFloat scaledFontSize(CGFloat fontSize, CGFloat fontSizeMultiplier)
-{
-  if (fontSizeMultiplier <= 0.0 || fontSizeMultiplier == 1.0) {
-    return fontSize;
-  }
-  return std::round(fontSize * fontSizeMultiplier);
+  return clampFontSizeMultiplier(props.allowFontScaling, props.maxFontSizeMultiplier, baseMultiplier);
 }
 
 UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
@@ -454,7 +400,7 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
   CGFloat fontSize = scaledFontSize(props.fontSize, fontSizeMultiplier);
   bool italic = props.fontStyle == RNPlainTextFontStyle::Italic;
   std::string faceKey = faceCacheKey(props.fontFamily, props.fontWeight, italic);
-  NSString *key = fontCacheKey(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);
+  NSString *key = fontCacheKeyString(faceKey, fontSize, props.fontVariant, props.fontVariationSettings);
 
   NSCache<NSString *, UIFont *> *cache = fontCache();
   UIFont *font = [cache objectForKey:key];

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -3,6 +3,7 @@
 #import "PlainTextFontVariations.h"
 
 #import <CoreText/CoreText.h>
+#import <React/RCTFont.h>
 #import <React/RCTLog.h>
 
 #import <cmath>
@@ -33,6 +34,77 @@ static UIFontWeight fontWeightFromProp(const std::string &fontWeight)
   NSString *key = [NSString stringWithUTF8String:fontWeight.c_str()];
   NSNumber *weight = weights[key];
   return weight != nil ? (UIFontWeight)weight.doubleValue : UIFontWeightRegular;
+}
+
+/*
+ * Face selection within a font family, taken from React Native's own
+ * RCTFont.mm, so that a custom fontFamily resolves to exactly the face RN's
+ * <Text> would pick rather than merely a similar one.
+ *
+ * Based on: https://github.com/facebook/react-native/blob/main/packages/react-native/React/Views/RCTFont.mm
+ *
+ * The weight lookup is not copied: RCTGetFontWeight is RCT_EXTERN in
+ * <React/RCTFont.h>, so it is called directly and cannot drift. isItalicFont
+ * and isCondensedFont below are static in RCTFont.mm, and the face loop is
+ * inline in +updateFont:withFamily:size:weight:style:variant:scaleMultiplier:,
+ * so there is nothing to link against for either.
+ */
+
+static BOOL isItalicFont(UIFont *font)
+{
+  return (CTFontGetSymbolicTraits((CTFontRef)font) & kCTFontTraitItalic) != 0;
+}
+
+static BOOL isCondensedFont(UIFont *font)
+{
+  return (CTFontGetSymbolicTraits((CTFontRef)font) & kCTFontTraitCondensed) != 0;
+}
+
+/*
+ * The face in this family closest to the requested weight and slant.
+ *
+ * Based on: https://github.com/facebook/react-native/blob/main/packages/react-native/React/Views/RCTFont.mm
+ *
+ *   - RN's `didFindFont` guard is dropped. It exists so RN can skip the loop
+ *     after its system-font special case, which this function is never reached
+ *     for — an empty fontFamily takes the systemFontOfSize: path in
+ *     plainTextFont instead.
+ *   - `isCondensed` is a local NO rather than a parameter. RN derives it from
+ *     the UIFont it is updating in place and from the "SystemCondensed" family
+ *     name; this library has neither, so RN's value is constant NO here.
+ *
+ * Deliberately not UIFontDescriptorFamilyAttribute + UIFontWeightTrait, which
+ * is what this replaced: descriptor matching leans on the very weight trait
+ * that RCTGetFontWeight goes out of its way to consult last, and an unmatched
+ * descriptor resolves to the system font instead of failing — the silent
+ * fallback this whole path exists to avoid.
+ */
+static UIFont *
+closestFaceInFamily(NSArray<NSString *> *names, CGFloat fontSize, RCTFontWeight fontWeight, BOOL isItalic)
+{
+  BOOL isCondensed = NO;
+  UIFont *font = nil;
+
+  // Get the closest font that matches the given weight for the fontFamily
+  CGFloat closestWeight = INFINITY;
+  for (NSString *name in names) {
+    UIFont *match = [UIFont fontWithName:name size:fontSize];
+    if (isItalic == isItalicFont(match) && isCondensed == isCondensedFont(match)) {
+      CGFloat testWeight = RCTGetFontWeight(match);
+      if (ABS(testWeight - fontWeight) < ABS(closestWeight - fontWeight)) {
+        font = match;
+        closestWeight = testWeight;
+      }
+    }
+  }
+
+  // If we still don't have a match at least return the first font in the fontFamily
+  // This is to support built-in font Zapfino and other custom single font families like Impact
+  if (!font && names.count > 0) {
+    font = [UIFont fontWithName:names[0] size:fontSize];
+  }
+
+  return font;
 }
 
 // Mirrors RCTFont.mm's RCTFontVariantDescriptor map: each fontVariant name
@@ -246,39 +318,50 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSize)
   UIFontWeight weight = fontWeightFromProp(props.fontWeight);
   if (!props.fontFamily.empty()) {
     NSString *fontFamily = [NSString stringWithUTF8String:props.fontFamily.c_str()];
-    // Resolve via the family's font names, as RCTFont.mm does: fontFamily is
-    // usually a face/PostScript name ("OpenRunde-Bold" in family "Open Runde")
-    // or an expo-font alias, and UIFontDescriptorFamilyAttribute matches neither.
-    // A single name is a face, which already picks the cut, so it skips weight.
     NSArray<NSString *> *fontNames = [UIFont fontNamesForFamilyName:fontFamily];
-    if (fontNames.count == 0) {
-      font = [UIFont fontWithName:fontFamily size:fontSize];
-    } else if (fontNames.count == 1) {
-      font = [UIFont fontWithName:fontNames.firstObject size:fontSize];
+    if (fontNames.count > 0) {
+      font = closestFaceInFamily(fontNames, fontSize, weight, italic);
     } else {
-      UIFontDescriptor *descriptor = [UIFontDescriptor fontDescriptorWithFontAttributes:@{
-        UIFontDescriptorFamilyAttribute : fontFamily,
-        UIFontDescriptorTraitsAttribute : @{UIFontWeightTrait : @(weight)},
-      }];
-      font = [UIFont fontWithDescriptor:descriptor size:fontSize];
+      // Not a registered family, so take it for the face / PostScript name it
+      // probably is ("OpenRunde-Bold" rather than "Open Runde"). An expo-font
+      // alias lands in the branch above instead: the swizzled
+      // +fontNamesForFamilyName: answers it with a one-element array.
+      font = [UIFont fontWithName:fontFamily size:fontSize];
+      if (font == nil) {
+        // Same message and same level as RCTFont.mm, from the same branch, so a
+        // typo reads identically whether it hit <PlainText> or <Text>. Info
+        // rather than warn keeps it out of LogBox, which is RN's call, not ours
+        // — the substitution is cosmetic, and this fires once per cache miss
+        // (so once per distinct fontSize, not once per commit).
+        RCTLogInfo(@"Unrecognized font family '%@'", fontFamily);
+      }
     }
-  } else {
+  }
+
+  // No fontFamily, or one naming neither a known family nor a known face — the
+  // latter is RCTFont.mm's fallback too. Everything downstream needs a real
+  // font: the italic round-trip below, and both callers, which read
+  // font.lineHeight to cap numberOfLines and would otherwise measure and draw
+  // with different defaults.
+  if (font == nil) {
     font = [UIFont systemFontOfSize:fontSize weight:weight];
   }
 
-  if (italic) {
+  // Only when the resolved face isn't already italic — closestFaceInFamily
+  // prefers the family's real italic cut, which beats a synthesized slant.
+  if (italic && !isItalicFont(font)) {
     UIFontDescriptor *italicDescriptor = [font.fontDescriptor
         fontDescriptorWithSymbolicTraits:font.fontDescriptor.symbolicTraits | UIFontDescriptorTraitItalic];
-    font = [UIFont fontWithDescriptor:italicDescriptor size:fontSize];
+    font = [UIFont fontWithDescriptor:italicDescriptor size:fontSize] ?: font;
   }
 
   // Last, as in RCTFont.mm: the features are added to whatever descriptor the
   // family/weight/italic resolution ended up with.
   NSArray<NSDictionary *> *features = fontFeatureSettings(props.fontVariant);
-  if (features != nil && font != nil) {
+  if (features != nil) {
     UIFontDescriptor *featureDescriptor = [font.fontDescriptor
         fontDescriptorByAddingAttributes:@{UIFontDescriptorFeatureSettingsAttribute : features}];
-    font = [UIFont fontWithDescriptor:featureDescriptor size:fontSize];
+    font = [UIFont fontWithDescriptor:featureDescriptor size:fontSize] ?: font;
   }
 
   // Variable-font axes, three things worth knowing:
@@ -298,7 +381,7 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSize)
   //   own axes are private, so this needs a registered variable family to do
   //   anything, and silently does nothing without one.
   NSDictionary<NSNumber *, NSNumber *> *variations = fontVariations(props.fontVariationSettings);
-  if (variations != nil && font != nil) {
+  if (variations != nil) {
     CTFontDescriptorRef variationDescriptor = CTFontDescriptorCreateWithAttributes(
         (__bridge CFDictionaryRef) @{(__bridge id)kCTFontVariationAttribute : variations});
     UIFont *variedFont = (__bridge_transfer UIFont *)CTFontCreateCopyWithAttributes(
@@ -309,9 +392,10 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSize)
     }
   }
 
-  if (font != nil) {
-    [cache setObject:font forKey:key];
-  }
+  // Every round-trip above keeps the font it started from if the descriptor
+  // fails to resolve, so `font` is non-nil from the fallback onwards — no guard
+  // needed here, and NSCache would raise on a nil object.
+  [cache setObject:font forKey:key];
   return font;
 }
 

--- a/ios/PlainTextFont.mm
+++ b/ios/PlainTextFont.mm
@@ -428,18 +428,22 @@ UIFont *plainTextFont(const RNPlainTextProps &props, CGFloat fontSizeMultiplier)
   }
 
   UIFontWeight weight = fontWeightFromProp(props.fontWeight);
-  if (!props.fontFamily.empty()) {
+  // "System" is RCTFont.mm's own special case for the system font by name
+  // (RN's <Text> accepts it the same way), so it's excluded here rather than
+  // sent through the family lookup below, where no family is actually
+  // registered as "System" and it would only fail and log.
+  if (!props.fontFamily.empty() && props.fontFamily != "System") {
     NSString *faceName = resolvedFaceName(props.fontFamily, faceKey, weight, italic);
     if (faceName != nil) {
       font = [UIFont fontWithName:faceName size:fontSize];
     }
   }
 
-  // No fontFamily, or one naming neither a known family nor a known face — the
-  // latter is RCTFont.mm's fallback too. Everything downstream needs a real
-  // font: the italic round-trip below, and both callers, which read
-  // font.lineHeight to cap numberOfLines and would otherwise measure and draw
-  // with different defaults.
+  // No fontFamily (or "System"), or one naming neither a known family nor a
+  // known face — the latter is RCTFont.mm's fallback too. Everything
+  // downstream needs a real font: the italic round-trip below, and both
+  // callers, which read font.lineHeight to cap numberOfLines and would
+  // otherwise measure and draw with different defaults.
   if (font == nil) {
     font = [UIFont systemFontOfSize:fontSize weight:weight];
   }

--- a/ios/PlainTextFontCache.h
+++ b/ios/PlainTextFontCache.h
@@ -1,0 +1,37 @@
+/*
+ * A key -> object cache that invalidates itself whenever fonts are
+ * registered or unregistered at runtime (expo-font,
+ * CTFontManagerRegisterFontsForURL), since that changes what a fontFamily
+ * resolves to — RCTFont.mm clears its own family-name cache on the same
+ * notification. PlainTextFont.mm's three caches (family face names, resolved
+ * face name, resolved UIFont) each wrap one of these instead of repeating the
+ * NSCache/notification wiring.
+ *
+ * A miss runs `compute` and stores whatever it returns, nil included: nil
+ * means "cache this as unresolvable" rather than "don't cache", since
+ * re-deriving that a fontFamily is unresolvable costs the same font-database
+ * walk (and the same log line) as deriving it the first time. Callers don't
+ * need their own sentinel for this, unlike a raw NSCache, which cannot store
+ * nil at all.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PlainTextFontCache<KeyType : NSString *, ObjectType : id> : NSObject
+
+/*
+ * `countLimit` of 0 means unlimited, same as NSCache's own default.
+ */
+- (instancetype)initWithCountLimit:(NSUInteger)countLimit;
+
+/*
+ * `key`'s cached value. On a miss, `compute` runs once, its result is stored
+ * under `key`, and that result is returned.
+ */
+- (nullable ObjectType)objectForKey:(KeyType)key orSet:(ObjectType _Nullable (^)(void))compute;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/PlainTextFontCache.mm
+++ b/ios/PlainTextFontCache.mm
@@ -1,0 +1,42 @@
+#import "PlainTextFontCache.h"
+
+#import <CoreText/CoreText.h>
+
+@implementation PlainTextFontCache {
+  NSCache<NSString *, id> *_cache;
+}
+
+- (instancetype)initWithCountLimit:(NSUInteger)countLimit
+{
+  if (self = [super init]) {
+    _cache = [NSCache new];
+    _cache.countLimit = countLimit;
+
+    // __weak would race +removeAllObjects against -dealloc for no benefit:
+    // every instance is held in a static local for the process lifetime (see
+    // PlainTextFont.mm), so it, and this observer, never gets torn down.
+    NSCache<NSString *, id> *cache = _cache;
+    [NSNotificationCenter.defaultCenter
+        addObserverForName:(NSNotificationName)kCTFontManagerRegisteredFontsChangedNotification
+                    object:nil
+                     queue:nil
+                usingBlock:^(NSNotification *) {
+                  [cache removeAllObjects];
+                }];
+  }
+  return self;
+}
+
+- (nullable id)objectForKey:(NSString *)key orSet:(id _Nullable (^)(void))compute
+{
+  id cached = [_cache objectForKey:key];
+  if (cached != nil) {
+    return cached == NSNull.null ? nil : cached;
+  }
+
+  id value = compute();
+  [_cache setObject:(value ?: NSNull.null) forKey:key];
+  return value;
+}
+
+@end

--- a/ios/PlainTextFontCacheKey.cpp
+++ b/ios/PlainTextFontCacheKey.cpp
@@ -8,13 +8,13 @@ namespace {
 constexpr char kFieldSeparator = '|';
 } // namespace
 
-std::string faceCacheKey(const std::string &fontFamily, const std::string &fontWeight, bool italic)
+std::string faceCacheKey(const std::string &fontFamily, const std::string &fontWeight, const std::string &fontStyle)
 {
   std::string key = fontFamily;
   key += kFieldSeparator;
   key += fontWeight;
   key += kFieldSeparator;
-  key += italic ? 'i' : 'n';
+  key += fontStyle;
   return key;
 }
 

--- a/ios/PlainTextFontCacheKey.cpp
+++ b/ios/PlainTextFontCacheKey.cpp
@@ -1,5 +1,7 @@
 #include "PlainTextFontCacheKey.h"
 
+#include <cmath>
+
 namespace facebook::react {
 
 namespace {

--- a/ios/PlainTextFontCacheKey.cpp
+++ b/ios/PlainTextFontCacheKey.cpp
@@ -1,0 +1,41 @@
+#include "PlainTextFontCacheKey.h"
+
+namespace facebook::react {
+
+namespace {
+constexpr char kFieldSeparator = '|';
+} // namespace
+
+std::string faceCacheKey(const std::string &fontFamily, const std::string &fontWeight, bool italic)
+{
+  std::string key = fontFamily;
+  key += kFieldSeparator;
+  key += fontWeight;
+  key += kFieldSeparator;
+  key += italic ? 'i' : 'n';
+  return key;
+}
+
+std::string fontCacheKey(
+    const std::string &faceKey,
+    double fontSize,
+    const std::vector<std::string> &fontVariant,
+    const std::string &fontVariationSettings)
+{
+  std::string key = faceKey;
+  key += kFieldSeparator;
+  // Hundredths of a point, as an integer — sidestepping the padded
+  // "17.000000" that std::to_string gives a double, and the cost of formatting
+  // one. Sizes closer together than that render identically at any screen
+  // scale, so collapsing them onto one entry is correct rather than lossy.
+  key += std::to_string(std::lround(fontSize * 100));
+  for (const std::string &variant : fontVariant) {
+    key += kFieldSeparator;
+    key += variant;
+  }
+  key += kFieldSeparator;
+  key += fontVariationSettings;
+  return key;
+}
+
+} // namespace facebook::react

--- a/ios/PlainTextFontCacheKey.h
+++ b/ios/PlainTextFontCacheKey.h
@@ -14,16 +14,22 @@ namespace facebook::react {
 
 /*
  * The three inputs that decide which face of a family to use: fontFamily,
- * fontWeight and italic. Also the leading fields of fontCacheKey below, so one
- * string serves both and the shared part is built once.
+ * fontWeight and fontStyle. Also the leading fields of fontCacheKey below, so
+ * one string serves both and the shared part is built once.
  *
- * fontFamily and fontWeight are adjacent free-form strings, so a separator
- * inside either shifts the boundary between them — family "Foo|" at weight
- * "bold" keys the same as family "Foo" at weight "|bold". Left unguarded: it
- * takes a fontWeight no real style produces, and the worst case is one wrong
- * font, consistently, since both callers share the key.
+ * fontStyle is the raw prop string (possibly empty, meaning "not passed"),
+ * not a converted bool: an empty string and "normal" both mean "not italic"
+ * but resolve differently once a fontFamily turns out to name a face rather
+ * than a family (see computeFaceName's fallback in PlainTextFont.mm), so they
+ * need distinct cache entries.
+ *
+ * fontFamily, fontWeight and fontStyle are adjacent free-form strings, so a
+ * separator inside any of them shifts the boundary between fields — family
+ * "Foo|" at weight "bold" keys the same as family "Foo" at weight "|bold".
+ * Left unguarded: it takes a fontWeight no real style produces, and the worst
+ * case is one wrong font, consistently, since both callers share the key.
  */
-std::string faceCacheKey(const std::string &fontFamily, const std::string &fontWeight, bool italic);
+std::string faceCacheKey(const std::string &fontFamily, const std::string &fontWeight, const std::string &fontStyle);
 
 /*
  * The face key plus the three inputs that don't affect face selection:

--- a/ios/PlainTextFontCacheKey.h
+++ b/ios/PlainTextFontCacheKey.h
@@ -1,0 +1,44 @@
+/*
+ * Plain C++ helpers behind PlainTextFont.mm's font cache: how its key is
+ * built from the inputs that decide face and font selection. Split out the
+ * same way PlainTextFontVariations.cpp was, so this logic runs under
+ * tests/cpp/ instead of only inside a UIFont round-trip.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace facebook::react {
+
+/*
+ * The three inputs that decide which face of a family to use: fontFamily,
+ * fontWeight and italic. Also the leading fields of fontCacheKey below, so one
+ * string serves both and the shared part is built once.
+ *
+ * fontFamily and fontWeight are adjacent free-form strings, so a separator
+ * inside either shifts the boundary between them — family "Foo|" at weight
+ * "bold" keys the same as family "Foo" at weight "|bold". Left unguarded: it
+ * takes a fontWeight no real style produces, and the worst case is one wrong
+ * font, consistently, since both callers share the key.
+ */
+std::string faceCacheKey(const std::string &fontFamily, const std::string &fontWeight, bool italic);
+
+/*
+ * The face key plus the three inputs that don't affect face selection:
+ * fontSize, fontVariant and fontVariationSettings.
+ *
+ * The variant names and the variation settings go last, where the separator
+ * ambiguity above is unreachable: every name the mapping recognizes is
+ * separator-free, and a separator inside the settings string makes it
+ * unparseable, so any pair of keys that could be misread for one another
+ * resolves to the same font, with no features and no axes.
+ */
+std::string fontCacheKey(
+    const std::string &faceKey,
+    double fontSize,
+    const std::vector<std::string> &fontVariant,
+    const std::string &fontVariationSettings);
+
+} // namespace facebook::react

--- a/ios/PlainTextFontLookupTables.h
+++ b/ios/PlainTextFontLookupTables.h
@@ -21,6 +21,16 @@ namespace facebook::react {
 RCTFontWeight fontWeightFromProp(const std::string &fontWeight);
 
 /*
+ * Mirrors RCTFont.mm's RCTFontStyle map (RCTConvert RCTFontStyle): "italic"
+ * and "oblique" are italic, everything else — including an empty string,
+ * which is codegen's stand-in for fontStyle not being passed at all — isn't.
+ * Callers that need to tell "not passed" apart from an explicit "normal"
+ * check the raw string themselves (see computeFaceName in PlainTextFont.mm);
+ * this only answers the simpler "should this render slanted" question.
+ */
+bool isItalicFromProp(const std::string &fontStyle);
+
+/*
  * Mirrors RCTFont.mm's RCTFontVariantDescriptor map: each fontVariant name
  * names one OpenType feature, expressed as the type/selector identifier pair
  * UIFontDescriptor takes. Unrecognized names have no entry, as RN drops them.

--- a/ios/PlainTextFontLookupTables.h
+++ b/ios/PlainTextFontLookupTables.h
@@ -5,6 +5,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <React/RCTFont.h>
 
 #import <string>
 
@@ -17,7 +18,7 @@ namespace facebook::react {
  * PlainTextViewNativeComponent.ts). Unrecognized or empty input maps to
  * UIFontWeightRegular, RCTFont.mm's own default.
  */
-UIFontWeight fontWeightFromProp(const std::string &fontWeight);
+RCTFontWeight fontWeightFromProp(const std::string &fontWeight);
 
 /*
  * Mirrors RCTFont.mm's RCTFontVariantDescriptor map: each fontVariant name

--- a/ios/PlainTextFontLookupTables.h
+++ b/ios/PlainTextFontLookupTables.h
@@ -1,0 +1,29 @@
+/*
+ * Static NSDictionary lookup tables mirroring RCTFont.mm's own prop-name
+ * maps, split out of PlainTextFont.mm so its resolution logic isn't
+ * interleaved with these tables' raw data.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import <string>
+
+namespace facebook::react {
+
+/*
+ * Mirrors RCTFont.mm's core weight map (RCTConvert RCTFontWeight): the named
+ * aliases beyond "normal"/"bold" (e.g. "ultralight", "condensed") are dropped
+ * since codegen can't type fontWeight as an enum (see
+ * PlainTextViewNativeComponent.ts). Unrecognized or empty input maps to
+ * UIFontWeightRegular, RCTFont.mm's own default.
+ */
+UIFontWeight fontWeightFromProp(const std::string &fontWeight);
+
+/*
+ * Mirrors RCTFont.mm's RCTFontVariantDescriptor map: each fontVariant name
+ * names one OpenType feature, expressed as the type/selector identifier pair
+ * UIFontDescriptor takes. Unrecognized names have no entry, as RN drops them.
+ */
+NSDictionary<NSString *, NSDictionary *> *fontVariantDescriptors(void);
+
+} // namespace facebook::react

--- a/ios/PlainTextFontLookupTables.mm
+++ b/ios/PlainTextFontLookupTables.mm
@@ -1,0 +1,74 @@
+#import "PlainTextFontLookupTables.h"
+
+#import <CoreText/CoreText.h>
+
+namespace facebook::react {
+
+UIFontWeight fontWeightFromProp(const std::string &fontWeight)
+{
+  static NSDictionary<NSString *, NSNumber *> *weights = @{
+    @"normal" : @(UIFontWeightRegular),
+    @"bold" : @(UIFontWeightBold),
+    @"100" : @(UIFontWeightUltraLight),
+    @"200" : @(UIFontWeightThin),
+    @"300" : @(UIFontWeightLight),
+    @"400" : @(UIFontWeightRegular),
+    @"500" : @(UIFontWeightMedium),
+    @"600" : @(UIFontWeightSemibold),
+    @"700" : @(UIFontWeightBold),
+    @"800" : @(UIFontWeightHeavy),
+    @"900" : @(UIFontWeightBlack),
+  };
+  NSString *key = [NSString stringWithUTF8String:fontWeight.c_str()];
+  NSNumber *weight = weights[key];
+  return weight != nil ? (UIFontWeight)weight.doubleValue : UIFontWeightRegular;
+}
+
+NSDictionary<NSString *, NSDictionary *> *fontVariantDescriptors(void)
+{
+  static NSDictionary<NSString *, NSDictionary *> *descriptors;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+#define RNPlainTextFeature(type, selector) \
+  @{UIFontFeatureTypeIdentifierKey : @(type), UIFontFeatureSelectorIdentifierKey : @(selector)}
+    descriptors = @{
+      @"small-caps" : RNPlainTextFeature(kLowerCaseType, kLowerCaseSmallCapsSelector),
+      @"oldstyle-nums" : RNPlainTextFeature(kNumberCaseType, kLowerCaseNumbersSelector),
+      @"lining-nums" : RNPlainTextFeature(kNumberCaseType, kUpperCaseNumbersSelector),
+      @"tabular-nums" : RNPlainTextFeature(kNumberSpacingType, kMonospacedNumbersSelector),
+      @"proportional-nums" : RNPlainTextFeature(kNumberSpacingType, kProportionalNumbersSelector),
+      @"common-ligatures" : RNPlainTextFeature(kLigaturesType, kCommonLigaturesOnSelector),
+      @"no-common-ligatures" : RNPlainTextFeature(kLigaturesType, kCommonLigaturesOffSelector),
+      @"discretionary-ligatures" : RNPlainTextFeature(kLigaturesType, kRareLigaturesOnSelector),
+      @"no-discretionary-ligatures" : RNPlainTextFeature(kLigaturesType, kRareLigaturesOffSelector),
+      @"historical-ligatures" : RNPlainTextFeature(kLigaturesType, kHistoricalLigaturesOnSelector),
+      @"no-historical-ligatures" : RNPlainTextFeature(kLigaturesType, kHistoricalLigaturesOffSelector),
+      @"contextual" : RNPlainTextFeature(kContextualAlternatesType, kContextualAlternatesOnSelector),
+      @"no-contextual" : RNPlainTextFeature(kContextualAlternatesType, kContextualAlternatesOffSelector),
+      @"stylistic-one" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltOneOnSelector),
+      @"stylistic-two" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltTwoOnSelector),
+      @"stylistic-three" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltThreeOnSelector),
+      @"stylistic-four" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltFourOnSelector),
+      @"stylistic-five" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltFiveOnSelector),
+      @"stylistic-six" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltSixOnSelector),
+      @"stylistic-seven" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltSevenOnSelector),
+      @"stylistic-eight" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltEightOnSelector),
+      @"stylistic-nine" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltNineOnSelector),
+      @"stylistic-ten" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltTenOnSelector),
+      @"stylistic-eleven" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltElevenOnSelector),
+      @"stylistic-twelve" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltTwelveOnSelector),
+      @"stylistic-thirteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltThirteenOnSelector),
+      @"stylistic-fourteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltFourteenOnSelector),
+      @"stylistic-fifteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltFifteenOnSelector),
+      @"stylistic-sixteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltSixteenOnSelector),
+      @"stylistic-seventeen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltSeventeenOnSelector),
+      @"stylistic-eighteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltEighteenOnSelector),
+      @"stylistic-nineteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltNineteenOnSelector),
+      @"stylistic-twenty" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltTwentyOnSelector),
+    };
+#undef RNPlainTextFeature
+  });
+  return descriptors;
+}
+
+} // namespace facebook::react

--- a/ios/PlainTextFontLookupTables.mm
+++ b/ios/PlainTextFontLookupTables.mm
@@ -25,6 +25,11 @@ RCTFontWeight fontWeightFromProp(const std::string &fontWeight)
   return weight != nil ? (RCTFontWeight)weight.doubleValue : UIFontWeightRegular;
 }
 
+bool isItalicFromProp(const std::string &fontStyle)
+{
+  return fontStyle == "italic" || fontStyle == "oblique";
+}
+
 NSDictionary<NSString *, NSDictionary *> *fontVariantDescriptors(void)
 {
 #define RNPlainTextFeature(type, selector) \

--- a/ios/PlainTextFontLookupTables.mm
+++ b/ios/PlainTextFontLookupTables.mm
@@ -1,10 +1,11 @@
 #import "PlainTextFontLookupTables.h"
 
 #import <CoreText/CoreText.h>
+#import <React/RCTFont.h>
 
 namespace facebook::react {
 
-UIFontWeight fontWeightFromProp(const std::string &fontWeight)
+RCTFontWeight fontWeightFromProp(const std::string &fontWeight)
 {
   static NSDictionary<NSString *, NSNumber *> *weights = @{
     @"normal" : @(UIFontWeightRegular),
@@ -21,7 +22,7 @@ UIFontWeight fontWeightFromProp(const std::string &fontWeight)
   };
   NSString *key = [NSString stringWithUTF8String:fontWeight.c_str()];
   NSNumber *weight = weights[key];
-  return weight != nil ? (UIFontWeight)weight.doubleValue : UIFontWeightRegular;
+  return weight != nil ? (RCTFontWeight)weight.doubleValue : UIFontWeightRegular;
 }
 
 NSDictionary<NSString *, NSDictionary *> *fontVariantDescriptors(void)

--- a/ios/PlainTextFontLookupTables.mm
+++ b/ios/PlainTextFontLookupTables.mm
@@ -26,12 +26,9 @@ UIFontWeight fontWeightFromProp(const std::string &fontWeight)
 
 NSDictionary<NSString *, NSDictionary *> *fontVariantDescriptors(void)
 {
-  static NSDictionary<NSString *, NSDictionary *> *descriptors;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
 #define RNPlainTextFeature(type, selector) \
   @{UIFontFeatureTypeIdentifierKey : @(type), UIFontFeatureSelectorIdentifierKey : @(selector)}
-    descriptors = @{
+  static NSDictionary<NSString *, NSDictionary *> *descriptors = @{
       @"small-caps" : RNPlainTextFeature(kLowerCaseType, kLowerCaseSmallCapsSelector),
       @"oldstyle-nums" : RNPlainTextFeature(kNumberCaseType, kLowerCaseNumbersSelector),
       @"lining-nums" : RNPlainTextFeature(kNumberCaseType, kUpperCaseNumbersSelector),
@@ -65,9 +62,8 @@ NSDictionary<NSString *, NSDictionary *> *fontVariantDescriptors(void)
       @"stylistic-eighteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltEighteenOnSelector),
       @"stylistic-nineteen" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltNineteenOnSelector),
       @"stylistic-twenty" : RNPlainTextFeature(kStylisticAlternativesType, kStylisticAltTwentyOnSelector),
-    };
+  };
 #undef RNPlainTextFeature
-  });
   return descriptors;
 }
 

--- a/ios/PlainTextFontSizing.cpp
+++ b/ios/PlainTextFontSizing.cpp
@@ -1,0 +1,26 @@
+#include "PlainTextFontSizing.h"
+
+#include <cmath>
+
+namespace facebook::react {
+
+double scaledFontSize(double fontSize, double fontSizeMultiplier)
+{
+  if (fontSizeMultiplier <= 0.0 || fontSizeMultiplier == 1.0) {
+    return fontSize;
+  }
+  return std::round(fontSize * fontSizeMultiplier);
+}
+
+double clampFontSizeMultiplier(bool allowFontScaling, double maxFontSizeMultiplier, double baseMultiplier)
+{
+  if (!allowFontScaling) {
+    return 1.0;
+  }
+  if (maxFontSizeMultiplier >= 1.0) {
+    return std::fmin(maxFontSizeMultiplier, baseMultiplier);
+  }
+  return baseMultiplier;
+}
+
+} // namespace facebook::react

--- a/ios/PlainTextFontSizing.h
+++ b/ios/PlainTextFontSizing.h
@@ -1,0 +1,31 @@
+/*
+ * Plain C++ font-size math shared by PlainTextFont.mm's font resolution and,
+ * for the multiplier, by its callers' own lineHeight scaling (see
+ * PlainTextShadowNode.mm and RNPlainText.mm). Split out the same way
+ * PlainTextFontVariations.cpp was, so this logic runs under tests/cpp/
+ * instead of only inside a UIFont round-trip.
+ */
+
+#pragma once
+
+namespace facebook::react {
+
+/*
+ * Rounded to whole points when a multiplier applies and left alone when none
+ * does, both as in RCTFont.mm — so a Dynamic Type setting lands on the same
+ * size RN's <Text> uses, and a fractional fontSize prop keeps its fraction.
+ */
+double scaledFontSize(double fontSize, double fontSizeMultiplier);
+
+/*
+ * The effective accessibility font-size multiplier: `baseMultiplier` when
+ * allowFontScaling is on, clamped by maxFontSizeMultiplier when that is >= 1,
+ * and 1 otherwise.
+ *
+ * Takes the three primitives PlainTextFont.h's plainTextFontSizeMultiplier
+ * reads off RNPlainTextProps, rather than the props struct itself, so this
+ * builds and runs without the codegen headers that struct needs.
+ */
+double clampFontSizeMultiplier(bool allowFontScaling, double maxFontSizeMultiplier, double baseMultiplier);
+
+} // namespace facebook::react

--- a/ios/PlainTextShadowNode.mm
+++ b/ios/PlainTextShadowNode.mm
@@ -30,7 +30,7 @@ Size PlainTextShadowNode::measureContent(
   // mounted view reads directly); the clamping on top of it is shared with that
   // view, so the measured size matches.
   CGFloat fontSizeMultiplier = plainTextFontSizeMultiplier(props, layoutContext.fontSizeMultiplier);
-  UIFont *font = plainTextFont(props, props.fontSize * fontSizeMultiplier);
+  UIFont *font = plainTextFont(props, plainTextScaledFontSize(props.fontSize, fontSizeMultiplier));
 
   // Build the same attributes the mounted UILabel renders with, so the measured
   // size matches. Kerning (letterSpacing) widens the text; a pinned line height

--- a/ios/PlainTextShadowNode.mm
+++ b/ios/PlainTextShadowNode.mm
@@ -30,7 +30,7 @@ Size PlainTextShadowNode::measureContent(
   // mounted view reads directly); the clamping on top of it is shared with that
   // view, so the measured size matches.
   CGFloat fontSizeMultiplier = plainTextFontSizeMultiplier(props, layoutContext.fontSizeMultiplier);
-  UIFont *font = plainTextFont(props, plainTextScaledFontSize(props.fontSize, fontSizeMultiplier));
+  UIFont *font = plainTextFont(props, fontSizeMultiplier);
 
   // Build the same attributes the mounted UILabel renders with, so the measured
   // size matches. Kerning (letterSpacing) widens the text; a pinned line height

--- a/ios/RNPlainText.mm
+++ b/ios/RNPlainText.mm
@@ -157,7 +157,7 @@ static NSLineBreakMode RNPlainTextLineBreakModeFromProp(RNPlainTextEllipsizeMode
 - (void)applyContentFromProps:(const RNPlainTextProps &)props
 {
     CGFloat fontSizeMultiplier = RNPlainTextFontSizeMultiplier(props);
-    UIFont *font = plainTextFont(props, props.fontSize * fontSizeMultiplier);
+    UIFont *font = plainTextFont(props, plainTextScaledFontSize(props.fontSize, fontSizeMultiplier));
     UIColor *color = props.color ? RCTUIColorFromSharedColor(props.color) : [UIColor blackColor];
     NSTextAlignment alignment = RNPlainTextAlignmentFromProp(props.textAlign);
     NSString *text = [NSString stringWithUTF8String:props.text.c_str()] ?: @"";

--- a/ios/RNPlainText.mm
+++ b/ios/RNPlainText.mm
@@ -157,7 +157,7 @@ static NSLineBreakMode RNPlainTextLineBreakModeFromProp(RNPlainTextEllipsizeMode
 - (void)applyContentFromProps:(const RNPlainTextProps &)props
 {
     CGFloat fontSizeMultiplier = RNPlainTextFontSizeMultiplier(props);
-    UIFont *font = plainTextFont(props, plainTextScaledFontSize(props.fontSize, fontSizeMultiplier));
+    UIFont *font = plainTextFont(props, fontSizeMultiplier);
     UIColor *color = props.color ? RCTUIColorFromSharedColor(props.color) : [UIColor blackColor];
     NSTextAlignment alignment = RNPlainTextAlignmentFromProp(props.textAlign);
     NSString *text = [NSString stringWithUTF8String:props.text.c_str()] ?: @"";

--- a/scripts/test-cpp.sh
+++ b/scripts/test-cpp.sh
@@ -34,3 +34,11 @@ run_suite font-variations \
   tests/cpp/PlainTextFontVariations.test.cpp \
   ios/PlainTextFontVariations.cpp \
   ios/PlainTextStringUtils.cpp
+
+run_suite font-cache-key \
+  tests/cpp/PlainTextFontCacheKey.test.cpp \
+  ios/PlainTextFontCacheKey.cpp
+
+run_suite font-sizing \
+  tests/cpp/PlainTextFontSizing.test.cpp \
+  ios/PlainTextFontSizing.cpp

--- a/src/PlainTextViewNativeComponent.ts
+++ b/src/PlainTextViewNativeComponent.ts
@@ -27,7 +27,15 @@ export interface NativeProps extends ViewProps {
   // instead (mirrors how RN's own <Text> types AndroidTextInputNativeComponent's
   // fontWeight as plain `string`).
   fontWeight?: string;
-  fontStyle?: CodegenTypes.WithDefault<'normal' | 'italic', 'normal'>;
+  // A free string rather than WithDefault<enum>, for the same reason as
+  // fontWeight above but a different symptom: codegen collapses "not passed"
+  // and the default value into the same C++ enum member, so native code has
+  // no way to tell "fontStyle: normal" apart from "fontStyle" never set at
+  // all. iOS's face-fallback path needs that distinction — RN's own
+  // RCTFont.mm keeps it by branching on the raw (possibly nil) style string
+  // rather than on the converted bool — so it's threaded through as a raw
+  // string the same way fontWeightProp is (see PlainTextFont.mm).
+  fontStyle?: string;
   // OpenType feature toggles, as RN <Text>'s fontVariant: variant names, each
   // mapping to one or more font features. Strings rather than a literal union
   // because codegen turns an array of enums into a bitmask enum; plain strings

--- a/tests/cpp/PlainTextFontCacheKey.test.cpp
+++ b/tests/cpp/PlainTextFontCacheKey.test.cpp
@@ -1,0 +1,99 @@
+/*
+ * Tables of inputs against expected results for the font-cache-key builders.
+ *
+ * Run with `yarn test:cpp`. No framework and no include paths, because the
+ * unit under test pulls in nothing but the standard library. Keep it that
+ * way.
+ */
+
+#include "../../ios/PlainTextFontCacheKey.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using facebook::react::faceCacheKey;
+using facebook::react::fontCacheKey;
+
+namespace {
+
+int failures = 0;
+
+void expectEqual(const std::string &what, const std::string &expected, const std::string &actual)
+{
+  if (expected == actual) {
+    return;
+  }
+  ++failures;
+  std::printf("FAIL %s\n  expected: \"%s\"\n  actual:   \"%s\"\n", what.c_str(), expected.c_str(), actual.c_str());
+}
+
+void expectEqual(const std::string &what, bool expected, bool actual)
+{
+  if (expected == actual) {
+    return;
+  }
+  ++failures;
+  std::printf("FAIL %s\n  expected: %d\n  actual:   %d\n", what.c_str(), expected, actual);
+}
+
+void testFaceCacheKey()
+{
+  expectEqual("distinct families don't collide", true, faceCacheKey("Foo", "bold", false) != faceCacheKey("Bar", "bold", false));
+  expectEqual("distinct weights don't collide", true, faceCacheKey("Foo", "bold", false) != faceCacheKey("Foo", "400", false));
+  expectEqual("italic changes the key", true, faceCacheKey("Foo", "bold", false) != faceCacheKey("Foo", "bold", true));
+  expectEqual(
+      "same inputs produce the same key",
+      faceCacheKey("Foo", "bold", true),
+      faceCacheKey("Foo", "bold", true));
+  // A separator inside a free-form field shifts the family/weight boundary,
+  // so this pair is documented to collide rather than crash or misparse.
+  expectEqual(
+      "a separator inside fontFamily shifts into fontWeight",
+      faceCacheKey("Foo|", "bold", false),
+      faceCacheKey("Foo", "|bold", false));
+}
+
+void testFontCacheKey()
+{
+  expectEqual(
+      "distinct sizes don't collide",
+      true,
+      fontCacheKey("face", 12, {}, "") != fontCacheKey("face", 13, {}, ""));
+  expectEqual(
+      "sizes closer than a hundredth of a point collapse onto one key",
+      fontCacheKey("face", 12.001, {}, ""),
+      fontCacheKey("face", 12.002, {}, ""));
+  expectEqual(
+      "distinct fontVariant lists don't collide",
+      true,
+      fontCacheKey("face", 12, {"small-caps"}, "") != fontCacheKey("face", 12, {}, ""));
+  expectEqual(
+      "variant order matters",
+      true,
+      fontCacheKey("face", 12, {"small-caps", "tabular-nums"}, "") !=
+          fontCacheKey("face", 12, {"tabular-nums", "small-caps"}, ""));
+  expectEqual(
+      "distinct fontVariationSettings don't collide",
+      true,
+      fontCacheKey("face", 12, {}, "'wght' 700") != fontCacheKey("face", 12, {}, "'wght' 400"));
+  expectEqual(
+      "same inputs produce the same key",
+      fontCacheKey("face", 12.5, {"small-caps"}, "'wght' 700"),
+      fontCacheKey("face", 12.5, {"small-caps"}, "'wght' 700"));
+}
+
+} // namespace
+
+int main()
+{
+  testFaceCacheKey();
+  testFontCacheKey();
+
+  if (failures > 0) {
+    std::printf("\nPlainTextFontCacheKey: %d failure(s)\n", failures);
+    return 1;
+  }
+  std::printf("PlainTextFontCacheKey: all cases passed\n");
+  return 0;
+}

--- a/tests/cpp/PlainTextFontCacheKey.test.cpp
+++ b/tests/cpp/PlainTextFontCacheKey.test.cpp
@@ -39,19 +39,23 @@ void expectEqual(const std::string &what, bool expected, bool actual)
 
 void testFaceCacheKey()
 {
-  expectEqual("distinct families don't collide", true, faceCacheKey("Foo", "bold", false) != faceCacheKey("Bar", "bold", false));
-  expectEqual("distinct weights don't collide", true, faceCacheKey("Foo", "bold", false) != faceCacheKey("Foo", "400", false));
-  expectEqual("italic changes the key", true, faceCacheKey("Foo", "bold", false) != faceCacheKey("Foo", "bold", true));
+  expectEqual("distinct families don't collide", true, faceCacheKey("Foo", "bold", "") != faceCacheKey("Bar", "bold", ""));
+  expectEqual("distinct weights don't collide", true, faceCacheKey("Foo", "bold", "") != faceCacheKey("Foo", "400", ""));
+  expectEqual("italic changes the key", true, faceCacheKey("Foo", "bold", "") != faceCacheKey("Foo", "bold", "italic"));
+  expectEqual(
+      "an unset fontStyle and an explicit \"normal\" don't collide",
+      true,
+      faceCacheKey("Foo", "bold", "") != faceCacheKey("Foo", "bold", "normal"));
   expectEqual(
       "same inputs produce the same key",
-      faceCacheKey("Foo", "bold", true),
-      faceCacheKey("Foo", "bold", true));
+      faceCacheKey("Foo", "bold", "italic"),
+      faceCacheKey("Foo", "bold", "italic"));
   // A separator inside a free-form field shifts the family/weight boundary,
   // so this pair is documented to collide rather than crash or misparse.
   expectEqual(
       "a separator inside fontFamily shifts into fontWeight",
-      faceCacheKey("Foo|", "bold", false),
-      faceCacheKey("Foo", "|bold", false));
+      faceCacheKey("Foo|", "bold", ""),
+      faceCacheKey("Foo", "|bold", ""));
 }
 
 void testFontCacheKey()

--- a/tests/cpp/PlainTextFontSizing.test.cpp
+++ b/tests/cpp/PlainTextFontSizing.test.cpp
@@ -1,0 +1,65 @@
+/*
+ * Tables of inputs against expected results for the font-size/multiplier
+ * math shared by PlainTextFont.mm's resolution and its callers' lineHeight
+ * scaling.
+ *
+ * Run with `yarn test:cpp`. No framework and no include paths, because the
+ * unit under test pulls in nothing but the standard library. Keep it that
+ * way.
+ */
+
+#include "../../ios/PlainTextFontSizing.h"
+
+#include <cstdio>
+#include <string>
+
+using facebook::react::clampFontSizeMultiplier;
+using facebook::react::scaledFontSize;
+
+namespace {
+
+int failures = 0;
+
+void expectEqual(const std::string &what, double expected, double actual)
+{
+  if (expected == actual) {
+    return;
+  }
+  ++failures;
+  std::printf("FAIL %s\n  expected: %g\n  actual:   %g\n", what.c_str(), expected, actual);
+}
+
+void testScaledFontSize()
+{
+  expectEqual("multiplier of 1 leaves fontSize untouched, fraction included", 17.5, scaledFontSize(17.5, 1.0));
+  expectEqual("multiplier of 0 leaves fontSize untouched", 17.5, scaledFontSize(17.5, 0.0));
+  expectEqual("a negative multiplier leaves fontSize untouched", 17.5, scaledFontSize(17.5, -1.0));
+  expectEqual("a real multiplier rounds to a whole point", 26.0, scaledFontSize(17.0, 1.5));
+  expectEqual("rounds down below the midpoint", 17.0, scaledFontSize(17.0, 1.02));
+  expectEqual("rounds up above the midpoint", 18.0, scaledFontSize(17.0, 1.04));
+}
+
+void testClampFontSizeMultiplier()
+{
+  expectEqual("allowFontScaling off ignores the base multiplier", 1.0, clampFontSizeMultiplier(false, 0, 2.0));
+  expectEqual("allowFontScaling off ignores maxFontSizeMultiplier too", 1.0, clampFontSizeMultiplier(false, 3.0, 2.0));
+  expectEqual("no max (< 1) passes the base multiplier through", 2.0, clampFontSizeMultiplier(true, 0, 2.0));
+  expectEqual("a max below the base multiplier clamps to it", 1.5, clampFontSizeMultiplier(true, 1.5, 2.0));
+  expectEqual("a max above the base multiplier doesn't raise it", 2.0, clampFontSizeMultiplier(true, 3.0, 2.0));
+  expectEqual("a max exactly at 1 is a real clamp, not \"no max\"", 1.0, clampFontSizeMultiplier(true, 1.0, 2.0));
+}
+
+} // namespace
+
+int main()
+{
+  testScaledFontSize();
+  testClampFontSizeMultiplier();
+
+  if (failures > 0) {
+    std::printf("\nPlainTextFontSizing: %d failure(s)\n", failures);
+    return 1;
+  }
+  std::printf("PlainTextFontSizing: all cases passed\n");
+  return 0;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,6 +1702,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo-google-fonts/inter@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "@expo-google-fonts/inter@npm:0.4.2"
+  checksum: 10c0/a88e6d1321584055d2fa265861795d55ec04b64d9726ecb60fd11a970252d23a1fd8c1febab7b587eb8ec699071d35c38c591625e44a2826c1e0e18bb1aa1946
+  languageName: node
+  linkType: hard
+
 "@expo/cli@npm:^57.0.11":
   version: 57.0.11
   resolution: "@expo/cli@npm:57.0.11"
@@ -10317,6 +10324,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-plain-text-example@workspace:example"
   dependencies:
+    "@expo-google-fonts/inter": "npm:^0.4.2"
     "@expo/metro-runtime": "npm:~57.0.8"
     "@expo/vector-icons": "npm:^15.0.2"
     "@react-navigation/bottom-tabs": "npm:^7.18.13"


### PR DESCRIPTION
On iOS a custom `fontFamily` is often ignored and the text silently falls back to the system font, while RN's `<Text>` renders the same value fine. Android is unaffected.

`plainTextFont` matches `UIFontDescriptorFamilyAttribute`, which only takes a registered *family* name. What arrives in `fontFamily` is usually a face / PostScript name, since that is what `expo-font` keys assets by (`OpenRunde-Bold` lives in family `Open Runde`). expo-font aliases miss too: it swizzles `+fontNamesForFamilyName:`, and CoreText descriptor matching does not call that.

Fix: resolve through the family's font names and `+fontWithName:`, as `RCTFont.mm` does for custom fonts. A single-entry list is a face and already picks the cut, so it skips the weight trait; only a real multi-face family gets weight matching.

Both iOS callers go through `plainTextFont`, so nothing to mirror per `docs/agent/sync-points.md`. `yarn validate` passes.

An earlier version of this PR guarded on `fontNamesForFamilyName:.count == 0`, which never fires in an Expo app because the swizzle returns a one-element array for an alias. The branch has been reset to `main` and rewritten.
