### PR TITLE
feat: `textTransform` style

### DIFF
--- a/android/src/main/java/com/mdjstack/plaintext/PlainTextView.kt
+++ b/android/src/main/java/com/mdjstack/plaintext/PlainTextView.kt
@@ -21,6 +21,8 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.views.text.ReactTypefaceUtils
+import java.text.BreakIterator
+import java.util.Locale
 import kotlin.math.ceil
 import kotlin.math.floor
 
@@ -52,6 +54,9 @@ class PlainTextView : AppCompatTextView {
   private var rawText: CharSequence? = null
   // NaN means unset, as in RN's TextAttributes.
   private var lineHeightSp: Float = Float.NaN
+  // null/"none" means unset. Applied inside applyText, since it transforms rawText
+  // before it reaches TextView.
+  private var textTransform: String? = null
 
   private var fontFamily: String? = null
   private var fontWeight: Int = ReactConstants.UNSET
@@ -226,9 +231,15 @@ class PlainTextView : AppCompatTextView {
     dirtyText = true
   }
 
+  // Mirrors <Text> (TextTransform.kt). null/"none" leaves the text untouched.
+  fun setTextTransform(value: String?) {
+    textTransform = value
+    dirtyText = true
+  }
+
   // The single place text reaches TextView, since a lineHeight span must be layered on.
   private fun applyText() {
-    val value = rawText ?: ""
+    val value = applyTextTransform(rawText?.toString() ?: "", textTransform)
     if (lineHeightSp.isNaN()) {
       setText(value)
       return
@@ -496,6 +507,35 @@ private fun toEffectivePixel(
     PixelUtil.toPixelFromSP(sp, maxFontSizeMultiplier)
   } else {
     PixelUtil.toPixelFromDIP(sp)
+  }
+}
+
+// Uppercase/lowercase mirror <Text> (com.facebook.react.views.text.TextTransform,
+// reimplemented here since that one is internal to RN's own module and not visible
+// outside it). Capitalize already matches CSS `text-transform: capitalize` and RN's
+// own Android behavior as-is: only the first character of each word is uppercased,
+// the rest is untouched. See ios/PlainTextTextTransform.h for why iOS deliberately
+// does not mirror RN's iOS capitalize, which force-lowercases the rest of each word.
+private fun applyTextTransform(text: String, textTransform: String?): String {
+  // EXPENSIVE: allocates a transformed copy of the string per call (docs/agent/performance.md);
+  // capitalize additionally walks word boundaries via BreakIterator below.
+  return when (textTransform) {
+    "uppercase" -> text.uppercase(Locale.getDefault())
+    "lowercase" -> text.lowercase(Locale.getDefault())
+    "capitalize" -> {
+      val wordIterator = BreakIterator.getWordInstance()
+      wordIterator.setText(text)
+      val result = StringBuilder(text.length)
+      var start = wordIterator.first()
+      var end = wordIterator.next()
+      while (end != BreakIterator.DONE) {
+        result.append(text.substring(start, end).replaceFirstChar { it.uppercaseChar() })
+        start = end
+        end = wordIterator.next()
+      }
+      result.toString()
+    }
+    else -> text
   }
 }
 

--- a/android/src/main/java/com/mdjstack/plaintext/PlainTextView.kt
+++ b/android/src/main/java/com/mdjstack/plaintext/PlainTextView.kt
@@ -510,15 +510,11 @@ private fun toEffectivePixel(
   }
 }
 
-// Uppercase/lowercase mirror <Text> (com.facebook.react.views.text.TextTransform,
-// reimplemented here since that one is internal to RN's own module and not visible
-// outside it). Capitalize already matches CSS `text-transform: capitalize` and RN's
-// own Android behavior as-is: only the first character of each word is uppercased,
-// the rest is untouched. See ios/PlainTextTextTransform.h for why iOS deliberately
-// does not mirror RN's iOS capitalize, which force-lowercases the rest of each word.
+// Mirrors <Text> (com.facebook.react.views.text.TextTransform, reimplemented here
+// since that one is internal to RN's own module). Capitalize already matches CSS
+// here; see ios/PlainTextTextTransform.h for why iOS needs its own implementation.
 private fun applyTextTransform(text: String, textTransform: String?): String {
-  // EXPENSIVE: allocates a transformed copy of the string per call (docs/agent/performance.md);
-  // capitalize additionally walks word boundaries via BreakIterator below.
+  // EXPENSIVE: allocates a transformed copy per call (docs/agent/performance.md).
   return when (textTransform) {
     "uppercase" -> text.uppercase(Locale.getDefault())
     "lowercase" -> text.lowercase(Locale.getDefault())

--- a/android/src/main/java/com/mdjstack/plaintext/PlainTextViewManager.kt
+++ b/android/src/main/java/com/mdjstack/plaintext/PlainTextViewManager.kt
@@ -120,6 +120,11 @@ class PlainTextViewManager : SimpleViewManager<PlainTextView>(),
     view?.setTextDecorationLine(textDecorationLine)
   }
 
+  @ReactProp(name = "textTransform")
+  override fun setTextTransform(view: PlainTextView?, textTransform: String?) {
+    view?.setTextTransform(textTransform)
+  }
+
   @ReactProp(name = "lineHeight")
   override fun setLineHeight(view: PlainTextView?, lineHeight: Float) {
     view?.setLineHeight(lineHeight)
@@ -211,6 +216,9 @@ class PlainTextViewManager : SimpleViewManager<PlainTextView>(),
     // applied for the measured size to match.
     view.setLetterSpacingDip(if (props?.hasKey("letterSpacing") == true) props.getDouble("letterSpacing").toFloat() else 0f)
     view.setLineHeight(if (props?.hasKey("lineHeight") == true) props.getDouble("lineHeight").toFloat() else 0f)
+    // Transforms the measured string itself (case changes can change width), so it
+    // must be applied before setPlainText below.
+    view.setTextTransform(props?.getString("textTransform"))
     // numberOfLines caps the measured height. ellipsizeMode only changes where the
     // ellipsis lands, so it isn't serialized for measure.
     view.setNumberOfLines(if (props?.hasKey("numberOfLines") == true) props.getInt("numberOfLines") else 0)

--- a/android/src/main/jni/react/renderer/components/RNPlainTextSpec/PlainTextMeasurementsManager.cpp
+++ b/android/src/main/jni/react/renderer/components/RNPlainTextSpec/PlainTextMeasurementsManager.cpp
@@ -58,6 +58,9 @@ folly::dynamic serializeProps(const RNPlainTextProps &props) {
   if (props.letterSpacing != 0.0) {
     serializedProps["letterSpacing"] = props.letterSpacing;
   }
+  if (props.textTransform != RNPlainTextTextTransform::None) {
+    serializedProps["textTransform"] = toString(props.textTransform);
+  }
   if (props.numberOfLines != 0) {
     serializedProps["numberOfLines"] = props.numberOfLines;
   }

--- a/cpp/PlainTextMeasurementHelpers.cpp
+++ b/cpp/PlainTextMeasurementHelpers.cpp
@@ -14,6 +14,7 @@ bool measurementInputsEqual(
       a.lineHeight == b.lineHeight &&
       a.letterSpacing == b.letterSpacing &&
       a.hasLetterSpacing == b.hasLetterSpacing &&
+      a.textTransform == b.textTransform &&
       a.numberOfLines == b.numberOfLines &&
       a.allowFontScaling == b.allowFontScaling &&
       a.maxFontSizeMultiplier == b.maxFontSizeMultiplier;

--- a/docs/agent/performance.md
+++ b/docs/agent/performance.md
@@ -53,6 +53,7 @@ of why it is still in [todo.md](todo.md).
 | `lineHeight`            | medium | Forces the iOS attributed-string path and an Android `SpannableString` with a span, in place of a plain string.                                                          |
 | `letterSpacing`         | medium | Forces the iOS attributed-string path. The Android side is one paint write.                                                                                              |
 | `textDecorationLine`    | medium | Forces the iOS attributed-string path. The Android side is two paint flags.                                                                                              |
+| `textTransform`         | medium | Allocates a transformed copy of the string per apply on both platforms; `capitalize` additionally walks word boundaries.                                                 |
 | everything else         | light  | One write, or one entry in the font cache key.                                                                                                                           |
 
 Three of those are medium for the same reason, and it is worth knowing as one

--- a/docs/agent/workflow.md
+++ b/docs/agent/workflow.md
@@ -38,23 +38,9 @@ closing `textAlignVertical` on iOS closed `verticalAlign` with it.
 
 ### When RN itself is wrong
 
-The same reasoning applies when RN's own behavior is a known bug rather than a
-platform gap: parity means matching CSS/web (what RN is trying to implement),
-not reproducing RN's bug on top of it.
-
-`textTransform: 'capitalize'` is this case on iOS. RN's iOS implementation
-force-lowercases every character in a word past the first ("PSYCHED" ->
-"Psyched"), which is RN's own known divergence from CSS
-`text-transform: capitalize` and from RN's own Android behavior
-(facebook/react-native#34117, open since 2022 with no fix attempted).
-`ios/PlainTextTextTransform.mm`'s `capitalizedString` does not mirror this: it
-uppercases only each Unicode word's first character, matching CSS and
-Android's Fabric `TextTransform` behavior instead.
-
-Say so where the divergence is implemented (`PlainTextTextTransform.h` and
-`.mm`, and `PlainTextView.kt`'s `applyTextTransform` comment) and in the
-example section's footer, so a reader comparing against a real RN `<Text>`
-overlay understands why a word with a mid-word capital won't match on iOS.
+Same reasoning when RN's own behavior is a known bug, not a platform gap:
+match CSS/web, not RN's bug. `textTransform: 'capitalize'` on iOS is this case
+(facebook/react-native#34117) — see `ios/PlainTextTextTransform.h`.
 
 ## Order of work
 

--- a/docs/agent/workflow.md
+++ b/docs/agent/workflow.md
@@ -36,6 +36,26 @@ the CSS name it was never a second gap.
 `PlainText.native.tsx`'s `resolveTextAlignVertical` mirrors that alias, and
 closing `textAlignVertical` on iOS closed `verticalAlign` with it.
 
+### When RN itself is wrong
+
+The same reasoning applies when RN's own behavior is a known bug rather than a
+platform gap: parity means matching CSS/web (what RN is trying to implement),
+not reproducing RN's bug on top of it.
+
+`textTransform: 'capitalize'` is this case on iOS. RN's iOS implementation
+force-lowercases every character in a word past the first ("PSYCHED" ->
+"Psyched"), which is RN's own known divergence from CSS
+`text-transform: capitalize` and from RN's own Android behavior
+(facebook/react-native#34117, open since 2022 with no fix attempted).
+`ios/PlainTextTextTransform.mm`'s `capitalizedString` does not mirror this: it
+uppercases only each Unicode word's first character, matching CSS and
+Android's Fabric `TextTransform` behavior instead.
+
+Say so where the divergence is implemented (`PlainTextTextTransform.h` and
+`.mm`, and `PlainTextView.kt`'s `applyTextTransform` comment) and in the
+example section's footer, so a reader comparing against a real RN `<Text>`
+overlay understands why a word with a mid-word capital won't match on iOS.
+
 ## Order of work
 
 1. **Add usage/test cases to the Features screen first.**

--- a/example/src/screens/FeaturesScreen.tsx
+++ b/example/src/screens/FeaturesScreen.tsx
@@ -369,6 +369,38 @@ export default function FeaturesScreen({ navigation }: Props) {
           </TextItem>
         ))}
       </Section>
+      <Section title="Text Transform" footer={TEXT_TRANSFORM_FOOTER}>
+        {TEXT_TRANSFORMS.map((textTransform) => (
+          <TextItem
+            key={textTransform}
+            label={textTransform}
+            showText={showText}
+            style={{ fontSize: SHORT_ROW_SIZE, textTransform }}
+          >
+            {TEXT_TRANSFORM_SPECIMEN}
+          </TextItem>
+        ))}
+        {/* capitalize's two gotchas (see ios/PlainTextTextTransform.mm and
+            PlainTextView.kt's applyTextTransform): a digit-led word and a
+            contraction, both of which a naive per-word titlecase would get
+            wrong. Chosen so they still match the RN <Text> overlay even
+            though PlainText's capitalize intentionally does not mirror RN's
+            iOS behavior in general (see the section footer). */}
+        <TextItem
+          label="capitalize, digit-led word"
+          showText={showText}
+          style={{ fontSize: SHORT_ROW_SIZE, textTransform: 'capitalize' }}
+        >
+          {TEXT_TRANSFORM_ORDINAL_SPECIMEN}
+        </TextItem>
+        <TextItem
+          label="capitalize, contraction"
+          showText={showText}
+          style={{ fontSize: SHORT_ROW_SIZE, textTransform: 'capitalize' }}
+        >
+          {TEXT_TRANSFORM_CONTRACTION_SPECIMEN}
+        </TextItem>
+      </Section>
       {/* Font scaling follows the OS accessibility text-size setting (Dynamic
           Type on iOS, Font size on Android). FONT_SCALING_FOOTER names the path
           for whichever platform is running. */}
@@ -794,6 +826,36 @@ const TEXT_DECORATION_LINES = [
   'line-through',
   'underline line-through',
 ] as const;
+
+const TEXT_TRANSFORMS = ['none', 'lowercase', 'uppercase', 'capitalize'] as const;
+
+const TEXT_TRANSFORM_SPECIMEN = 'Quick brown fox';
+
+// A digit has no uppercase form, so capitalize leaves a digit-led word alone
+// ("3rd", not "3Rd") with no special-casing needed: only each word's first
+// character is ever touched. The two words around it show the ordinary
+// per-word capitalization still applying everywhere else.
+const TEXT_TRANSFORM_ORDINAL_SPECIMEN = '3rd place winner';
+
+// Apostrophes stay inside the word rather than starting a new one (Unicode
+// word-boundary rules, both platforms), so capitalize touches only each
+// word's true first letter ("It's a trap, don't panic"), not the letter
+// right after the apostrophe.
+const TEXT_TRANSFORM_CONTRACTION_SPECIMEN = "it's a trap, don't panic";
+
+const TEXT_TRANSFORM_FOOTER =
+  "capitalize's two extra rows below: a digit-led word stays untouched past " +
+  'its first character, and an apostrophe stays inside its word instead of ' +
+  'starting a new one. Both match the RN <Text> overlay on either platform, ' +
+  "though PlainText's capitalize intentionally diverges from RN <Text> on iOS " +
+  'for a word that already has an uppercase letter past its first character ' +
+  '(e.g. "PSYCHED"): RN <Text> force-lowercases the rest of the word there ' +
+  "(facebook/react-native#34117, RN's own divergence from CSS " +
+  '`text-transform: capitalize`), PlainText does not. ' +
+  'On uppercase/capitalize, RN <Text> can size its own box to the untransformed ' +
+  "string rather than the transformed one it paints, so the scarlet overlay's " +
+  'edge can fall short of its own glyphs. PlainText measures the transformed ' +
+  'string, so its box always matches what it draws.';
 
 // The section needs a font that actually carries the features, and SF does not:
 // it forms no ff/ffi/ffl ligatures and ships no oldstyle figures, so those rows

--- a/example/src/screens/FeaturesScreen.tsx
+++ b/example/src/screens/FeaturesScreen.tsx
@@ -824,7 +824,9 @@ const TEXT_DECORATION_LINES = [
 
 const TEXT_TRANSFORMS = ['none', 'lowercase', 'uppercase', 'capitalize'] as const;
 
-const TEXT_TRANSFORM_SPECIMEN = 'Quick brown fox';
+// Mid-word caps ("BROWN") make capitalize's row visibly diverge from the
+// scarlet <Text> overlay on iOS: see TEXT_TRANSFORM_FOOTER.
+const TEXT_TRANSFORM_SPECIMEN = 'Quick BROWN fox';
 
 // A digit has no uppercase form, so capitalize leaves it alone.
 const TEXT_TRANSFORM_ORDINAL_SPECIMEN = '3rd place winner';
@@ -833,13 +835,7 @@ const TEXT_TRANSFORM_ORDINAL_SPECIMEN = '3rd place winner';
 const TEXT_TRANSFORM_CONTRACTION_SPECIMEN = "it's a trap, don't panic";
 
 const TEXT_TRANSFORM_FOOTER =
-  "capitalize matches CSS: only each word's first character is uppercased. " +
-  "RN <Text>'s iOS capitalize also lowercases the rest of the word " +
-  '(facebook/react-native#34117), so a mid-word capital (e.g. "PSYCHED") ' +
-  "won't match the scarlet overlay there, by design. On uppercase/capitalize, " +
-  "RN <Text> also sizes its box to the untransformed string, so the overlay's " +
-  'edge can fall short of its own glyphs. PlainText measures the transformed ' +
-  'string, so its box always matches what it draws.';
+  "RN <Text>'s capitalize has a bug on iOS (facebook/react-native#34117).";
 
 // The section needs a font that actually carries the features, and SF does not:
 // it forms no ff/ffi/ffl ligatures and ships no oldstyle figures, so those rows

--- a/example/src/screens/FeaturesScreen.tsx
+++ b/example/src/screens/FeaturesScreen.tsx
@@ -380,12 +380,7 @@ export default function FeaturesScreen({ navigation }: Props) {
             {TEXT_TRANSFORM_SPECIMEN}
           </TextItem>
         ))}
-        {/* capitalize's two gotchas (see ios/PlainTextTextTransform.mm and
-            PlainTextView.kt's applyTextTransform): a digit-led word and a
-            contraction, both of which a naive per-word titlecase would get
-            wrong. Chosen so they still match the RN <Text> overlay even
-            though PlainText's capitalize intentionally does not mirror RN's
-            iOS behavior in general (see the section footer). */}
+        {/* capitalize's two gotchas: a digit-led word and a contraction. */}
         <TextItem
           label="capitalize, digit-led word"
           showText={showText}
@@ -831,29 +826,18 @@ const TEXT_TRANSFORMS = ['none', 'lowercase', 'uppercase', 'capitalize'] as cons
 
 const TEXT_TRANSFORM_SPECIMEN = 'Quick brown fox';
 
-// A digit has no uppercase form, so capitalize leaves a digit-led word alone
-// ("3rd", not "3Rd") with no special-casing needed: only each word's first
-// character is ever touched. The two words around it show the ordinary
-// per-word capitalization still applying everywhere else.
+// A digit has no uppercase form, so capitalize leaves it alone.
 const TEXT_TRANSFORM_ORDINAL_SPECIMEN = '3rd place winner';
 
-// Apostrophes stay inside the word rather than starting a new one (Unicode
-// word-boundary rules, both platforms), so capitalize touches only each
-// word's true first letter ("It's a trap, don't panic"), not the letter
-// right after the apostrophe.
+// Apostrophes stay inside the word rather than starting a new one.
 const TEXT_TRANSFORM_CONTRACTION_SPECIMEN = "it's a trap, don't panic";
 
 const TEXT_TRANSFORM_FOOTER =
-  "capitalize's two extra rows below: a digit-led word stays untouched past " +
-  'its first character, and an apostrophe stays inside its word instead of ' +
-  'starting a new one. Both match the RN <Text> overlay on either platform, ' +
-  "though PlainText's capitalize intentionally diverges from RN <Text> on iOS " +
-  'for a word that already has an uppercase letter past its first character ' +
-  '(e.g. "PSYCHED"): RN <Text> force-lowercases the rest of the word there ' +
-  "(facebook/react-native#34117, RN's own divergence from CSS " +
-  '`text-transform: capitalize`), PlainText does not. ' +
-  'On uppercase/capitalize, RN <Text> can size its own box to the untransformed ' +
-  "string rather than the transformed one it paints, so the scarlet overlay's " +
+  "capitalize matches CSS: only each word's first character is uppercased. " +
+  "RN <Text>'s iOS capitalize also lowercases the rest of the word " +
+  '(facebook/react-native#34117), so a mid-word capital (e.g. "PSYCHED") ' +
+  "won't match the scarlet overlay there, by design. On uppercase/capitalize, " +
+  "RN <Text> also sizes its box to the untransformed string, so the overlay's " +
   'edge can fall short of its own glyphs. PlainText measures the transformed ' +
   'string, so its box always matches what it draws.';
 

--- a/example/src/screens/PerformanceScreen.tsx
+++ b/example/src/screens/PerformanceScreen.tsx
@@ -788,6 +788,19 @@ const ATTRIBUTES: AttrDef[] = [
     ],
   },
   {
+    key: 'textTransform',
+    section: 'Text',
+    fp: 'tt',
+    target: 'text',
+    options: [
+      { label: '(none)' },
+      { label: 'none', value: 'none' },
+      { label: 'uppercase', value: 'uppercase' },
+      { label: 'lowercase', value: 'lowercase' },
+      { label: 'capitalize', value: 'capitalize' },
+    ],
+  },
+  {
     key: 'textAlign',
     section: 'Text',
     fp: 'ta',

--- a/ios/PlainTextShadowNode.mm
+++ b/ios/PlainTextShadowNode.mm
@@ -7,6 +7,7 @@
 #import <cmath>
 
 #import "PlainTextFont.h"
+#import "PlainTextTextTransform.h"
 
 namespace facebook::react {
 
@@ -23,6 +24,7 @@ Size PlainTextShadowNode::measureContent(
   if (text == nil) {
     text = @"";
   }
+  text = plainTextApplyTextTransform(text, props.textTransform);
 
   // Base scale comes from the layout context (Fabric seeds it from
   // RCTFontSizeMultiplier, same as the mounted view). Clamping matches the

--- a/ios/PlainTextTextTransform.h
+++ b/ios/PlainTextTextTransform.h
@@ -1,0 +1,27 @@
+/*
+ * textTransform, shared by the mounted view and the shadow node so both
+ * transform the same text the same way, otherwise the measured box and the
+ * drawn text could disagree.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <react/renderer/components/RNPlainTextSpec/Props.h>
+
+namespace facebook::react {
+
+/*
+ * Applies `textTransform` to `text`. Uppercase/lowercase mirror RN <Text>'s own
+ * RCTNSStringFromStringApplyingTextTransform (RCTAttributedTextUtils.mm),
+ * reimplemented here since that function lives in a private RN target.
+ * Capitalize deliberately does not: RN's iOS capitalize force-lowercases the
+ * rest of each word (e.g. "PSYCHED" -> "Psyched"), which is RN's own known
+ * divergence from CSS `text-transform: capitalize` (facebook/react-native#34117)
+ * and from Android's Fabric implementation, which never touches anything past
+ * a word's first character. This uppercases only the first character of each
+ * Unicode word, matching CSS and Android instead of RN's iOS quirk.
+ */
+NSString *plainTextApplyTextTransform(NSString *text, RNPlainTextTextTransform textTransform);
+
+} // namespace facebook::react

--- a/ios/PlainTextTextTransform.h
+++ b/ios/PlainTextTextTransform.h
@@ -12,15 +12,12 @@
 namespace facebook::react {
 
 /*
- * Applies `textTransform` to `text`. Uppercase/lowercase mirror RN <Text>'s own
+ * Applies `textTransform` to `text`. Uppercase/lowercase mirror RN's own
  * RCTNSStringFromStringApplyingTextTransform (RCTAttributedTextUtils.mm),
- * reimplemented here since that function lives in a private RN target.
- * Capitalize deliberately does not: RN's iOS capitalize force-lowercases the
- * rest of each word (e.g. "PSYCHED" -> "Psyched"), which is RN's own known
- * divergence from CSS `text-transform: capitalize` (facebook/react-native#34117)
- * and from Android's Fabric implementation, which never touches anything past
- * a word's first character. This uppercases only the first character of each
- * Unicode word, matching CSS and Android instead of RN's iOS quirk.
+ * reimplemented here since it lives in a private RN target. Capitalize does
+ * not: RN's iOS capitalize also lowercases the rest of each word, diverging
+ * from CSS and from Android (facebook/react-native#34117). This matches CSS
+ * and Android instead, uppercasing only each word's first character.
  */
 NSString *plainTextApplyTextTransform(NSString *text, RNPlainTextTextTransform textTransform);
 

--- a/ios/PlainTextTextTransform.mm
+++ b/ios/PlainTextTextTransform.mm
@@ -1,0 +1,42 @@
+#import "PlainTextTextTransform.h"
+
+namespace facebook::react {
+
+// CSS `text-transform: capitalize` (and PlainTextView.kt's applyTextTransform on
+// Android): uppercase only each Unicode word's first character, leave the rest of
+// the word untouched. Deliberately not RN's iOS capitalizedString-based behavior
+// (see PlainTextTextTransform.h) since that force-lowercases the rest of every word.
+static NSString *capitalizedString(NSString *text)
+{
+    NSMutableString *result = [text mutableCopy];
+    [text enumerateSubstringsInRange:NSMakeRange(0, text.length)
+                              options:NSStringEnumerationByWords
+                           usingBlock:^(NSString *word, NSRange wordRange, NSRange enclosingRange, BOOL *stop) {
+        if (word.length == 0) {
+            return;
+        }
+        NSRange firstCharRange = [word rangeOfComposedCharacterSequenceAtIndex:0];
+        NSString *upperFirstChar = [word substringWithRange:firstCharRange].uppercaseString;
+        [result replaceCharactersInRange:NSMakeRange(wordRange.location + firstCharRange.location, firstCharRange.length)
+                               withString:upperFirstChar];
+    }];
+    return result;
+}
+
+NSString *plainTextApplyTextTransform(NSString *text, RNPlainTextTextTransform textTransform)
+{
+    // EXPENSIVE: allocates a transformed copy of the string per call (docs/agent/performance.md);
+    // Capitalize additionally enumerates Unicode word boundaries via capitalizedString above.
+    switch (textTransform) {
+        case RNPlainTextTextTransform::Uppercase:
+            return text.uppercaseString;
+        case RNPlainTextTextTransform::Lowercase:
+            return text.lowercaseString;
+        case RNPlainTextTextTransform::Capitalize:
+            return capitalizedString(text);
+        case RNPlainTextTextTransform::None:
+            return text;
+    }
+}
+
+} // namespace facebook::react

--- a/ios/PlainTextTextTransform.mm
+++ b/ios/PlainTextTextTransform.mm
@@ -2,10 +2,7 @@
 
 namespace facebook::react {
 
-// CSS `text-transform: capitalize` (and PlainTextView.kt's applyTextTransform on
-// Android): uppercase only each Unicode word's first character, leave the rest of
-// the word untouched. Deliberately not RN's iOS capitalizedString-based behavior
-// (see PlainTextTextTransform.h) since that force-lowercases the rest of every word.
+// See PlainTextTextTransform.h: uppercases only each word's first character.
 static NSString *capitalizedString(NSString *text)
 {
     NSMutableString *result = [text mutableCopy];
@@ -25,8 +22,7 @@ static NSString *capitalizedString(NSString *text)
 
 NSString *plainTextApplyTextTransform(NSString *text, RNPlainTextTextTransform textTransform)
 {
-    // EXPENSIVE: allocates a transformed copy of the string per call (docs/agent/performance.md);
-    // Capitalize additionally enumerates Unicode word boundaries via capitalizedString above.
+    // EXPENSIVE: allocates a transformed copy per call (docs/agent/performance.md).
     switch (textTransform) {
         case RNPlainTextTextTransform::Uppercase:
             return text.uppercaseString;

--- a/ios/RNPlainText.mm
+++ b/ios/RNPlainText.mm
@@ -7,6 +7,7 @@
 
 #import "PlainTextComponentDescriptor.h"
 #import "PlainTextFont.h"
+#import "PlainTextTextTransform.h"
 #import "RCTFabricComponentsPlugins.h"
 
 using namespace facebook::react;
@@ -158,6 +159,7 @@ static NSLineBreakMode RNPlainTextLineBreakModeFromProp(RNPlainTextEllipsizeMode
     UIColor *color = props.color ? RCTUIColorFromSharedColor(props.color) : [UIColor blackColor];
     NSTextAlignment alignment = RNPlainTextAlignmentFromProp(props.textAlign);
     NSString *text = [NSString stringWithUTF8String:props.text.c_str()] ?: @"";
+    text = plainTextApplyTextTransform(text, props.textTransform);
 
     BOOL hasLineHeight = props.lineHeight > 0;
     BOOL hasLetterSpacing = props.hasLetterSpacing;
@@ -262,6 +264,7 @@ static NSLineBreakMode RNPlainTextLineBreakModeFromProp(RNPlainTextEllipsizeMode
         oldViewProps.letterSpacing != newViewProps.letterSpacing ||
         oldViewProps.hasLetterSpacing != newViewProps.hasLetterSpacing ||
         oldViewProps.textDecorationLine != newViewProps.textDecorationLine ||
+        oldViewProps.textTransform != newViewProps.textTransform ||
         oldViewProps.ellipsizeMode != newViewProps.ellipsizeMode ||
         oldViewProps.allowFontScaling != newViewProps.allowFontScaling ||
         oldViewProps.maxFontSizeMultiplier != newViewProps.maxFontSizeMultiplier ||

--- a/src/PlainText.native.tsx
+++ b/src/PlainText.native.tsx
@@ -80,6 +80,7 @@ export function PlainText({
     textAlignVertical,
     verticalAlign,
     textDecorationLine,
+    textTransform,
     lineHeight,
     letterSpacing,
     ...viewStyle
@@ -98,6 +99,7 @@ export function PlainText({
       textAlign={textAlign}
       textAlignVertical={resolveTextAlignVertical(textAlignVertical, verticalAlign)}
       textDecorationLine={textDecorationLine}
+      textTransform={textTransform}
       lineHeight={lineHeight}
       letterSpacing={letterSpacing}
       hasLetterSpacing={letterSpacing !== undefined}

--- a/src/PlainTextViewNativeComponent.ts
+++ b/src/PlainTextViewNativeComponent.ts
@@ -53,6 +53,14 @@ export interface NativeProps extends ViewProps {
   //
   // Cost: medium. Forces iOS's attributed-string path and two Android paint flags.
   textDecorationLine?: string;
+  // Transforms the text content itself, so it feeds both what's drawn and what's
+  // measured (case changes can change width).
+  //
+  // Cost: medium. Allocates a transformed copy of the string per apply on both platforms.
+  textTransform?: CodegenTypes.WithDefault<
+    'none' | 'uppercase' | 'lowercase' | 'capitalize',
+    'none'
+  >;
   // 0 means unlimited. Caps rendered lines and the shadow node's measured intrinsic height.
   numberOfLines?: CodegenTypes.WithDefault<CodegenTypes.Int32, 0>;
   ellipsizeMode?: CodegenTypes.WithDefault<'head' | 'middle' | 'tail' | 'clip', 'tail'>;


### PR DESCRIPTION
This implements `capitalize` text transform in a way that's works the same way on iOS & Android (and is also coherent with web style).

RN however implements iOS `capitalize` text transform in an incorrect way:
- Web & Android: "Quick BROWN fox" ==> "Quick BROWN Fox"
- iOS: "Quick BROWN fox" ==> "Quick Brown Fox" (why???)

See RN Text issue: https://github.com/react/react-native/issues/34117