### PR TITLE
fix(android): scope test configuration to source builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,11 @@ apply plugin: "kotlin-android"
 
 apply plugin: "com.facebook.react"
 
+// The npm package excludes android/src/test, while the local example app includes this
+// directory directly. Only configure test resources and dependencies when sources exist.
+def androidTestDirectory = file("src/test")
+def hasAndroidTests = androidTestDirectory.isDirectory()
+
 android {
   namespace "com.mdjstack.plaintext"
 
@@ -46,10 +51,12 @@ android {
     minSdkVersion getExtOrDefault("minSdkVersion")
   }
 
-  // Robolectric reads the module's merged manifest and resources. Without this it runs
-  // against a stub R and fails on anything that resolves a theme attribute.
-  testOptions {
-    unitTests.includeAndroidResources = true
+  if (hasAndroidTests) {
+    // Robolectric reads the module's merged manifest and resources. Without this it runs
+    // against a stub R and fails on anything that resolves a theme attribute.
+    testOptions {
+      unitTests.includeAndroidResources = true
+    }
   }
 
   compileOptions {
@@ -61,6 +68,8 @@ android {
 dependencies {
   implementation "com.facebook.react:react-android"
 
-  testImplementation "junit:junit:4.13.2"
-  testImplementation "org.robolectric:robolectric:4.14.1"
+  if (hasAndroidTests) {
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.robolectric:robolectric:4.14.1"
+  }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,10 +37,9 @@ apply plugin: "kotlin-android"
 
 apply plugin: "com.facebook.react"
 
-// The npm package excludes android/src/test, while the local example app includes this
-// directory directly. Only configure test resources and dependencies when sources exist.
-def androidTestDirectory = file("src/test")
-def hasAndroidTests = androidTestDirectory.isDirectory()
+// Only a source checkout has android/src/test; the npm package strips it. Gating test
+// config off it avoids AGP failing testDebugUnitTest on an empty source set in consumers.
+def hasAndroidTests = file("src/test").isDirectory()
 
 android {
   namespace "com.mdjstack.plaintext"
@@ -52,8 +51,7 @@ android {
   }
 
   if (hasAndroidTests) {
-    // Robolectric reads the module's merged manifest and resources. Without this it runs
-    // against a stub R and fails on anything that resolves a theme attribute.
+    // Robolectric needs the merged manifest and resources, not a stub R.
     testOptions {
       unitTests.includeAndroidResources = true
     }


### PR DESCRIPTION
Hey,

in our app we run tests for the android project, and since installing react-native-plain-text they were failing with:

```

FAILURE: Build failed with an exception.
--
  |  
  | * What went wrong:
  | Execution failed for task ':react-native-plain-text:testDebugUnitTest'.
  | > There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration. If this is not a misconfiguration, this error can be disabled by setting the 'failOnNoDiscoveredTests' property to false.


```

That's because the build.gradle specified it has test options, so AGP registers the src/test/java path even when there are no files for it.

I think the proper fix is to gate the test option only when the files really exists (in source builds only).